### PR TITLE
Add agent ownership to MLflow traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ During runs you will see per-iteration exchanges (debate or addition/subtraction
 Install the `mlflow` extra, then add the global `--mlflow` flag before the command.
 MLflow's DSPy autologging captures module and language-model traces; the integration also
 records the pattern, topic, configuration path, outcome metrics, tags, and `session.json`.
+Pattern runs add a root `CHAIN` span and named `AGENT` spans for each participant, so
+the MLflow trace tree attributes nested DSPy/LM calls to roles such as affirmative,
+negative, judge, addition, and subtraction. The span with `agent.answer_owner=true`
+identifies the role responsible for the final answer.
 
 ```bash
 poetry install -E mlflow

--- a/awesome_dspy_agents/cli.py
+++ b/awesome_dspy_agents/cli.py
@@ -19,6 +19,7 @@ from awesome_dspy_agents.mlflow_integration import (
     MLflowConfig,
     MLflowIntegrationError,
     mlflow_run,
+    mlflow_span,
 )
 from awesome_dspy_agents.patterns.interface import discover_patterns
 from awesome_dspy_agents.runtime import (
@@ -178,16 +179,33 @@ def _execute_pattern(
             config_path=str(config_path),
             version=__version__,
         ) as tracking_run:
-            outcome = pat.run(
-                PatternRunRequest(
-                    topic=topic,
-                    config_path=config_path,
-                    overrides=overrides,
-                    allowed_paths=_allowed_paths,
-                    on_tool_event=_tool_listener,
-                ),
-                on_iteration=_on_iteration,
-            )
+            with mlflow_span(
+                f"pattern.{pattern_name}",
+                span_type="CHAIN",
+                inputs={"topic": topic},
+                attributes={
+                    "agent.pattern": pattern_name,
+                    "agent.config_path": str(config_path),
+                },
+            ) as pattern_span:
+                outcome = pat.run(
+                    PatternRunRequest(
+                        topic=topic,
+                        config_path=config_path,
+                        overrides=overrides,
+                        allowed_paths=_allowed_paths,
+                        on_tool_event=_tool_listener,
+                    ),
+                    on_iteration=_on_iteration,
+                )
+                if pattern_span is not None:
+                    pattern_span.set_outputs(
+                        {
+                            "final_answer": outcome.final_answer,
+                            "justification": outcome.justification,
+                            "iterations_used": outcome.iterations_used,
+                        }
+                    )
             result = asdict(outcome)
             record = {
                 "schema": 2,

--- a/awesome_dspy_agents/mlflow_integration.py
+++ b/awesome_dspy_agents/mlflow_integration.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 import importlib
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
+
+_tracing_enabled: ContextVar[bool] = ContextVar(
+    "awesome_dspy_agents_mlflow_tracing_enabled", default=False
+)
 
 
 class MLflowIntegrationError(RuntimeError):
@@ -56,6 +61,30 @@ def _load_mlflow() -> Any:
 
 
 @contextmanager
+def mlflow_span(
+    name: str,
+    *,
+    span_type: str,
+    inputs: Mapping[str, Any] | None = None,
+    attributes: Mapping[str, Any] | None = None,
+) -> Iterator[Any | None]:
+    """Create an application-level span only inside an enabled MLflow run."""
+
+    if not _tracing_enabled.get():
+        yield None
+        return
+
+    mlflow = _load_mlflow()
+    resolved_span_type = getattr(mlflow.entities.SpanType, span_type)
+    with mlflow.start_span(name=name, span_type=resolved_span_type) as span:
+        if inputs:
+            span.set_inputs(dict(inputs))
+        if attributes:
+            span.set_attributes(dict(attributes))
+        yield span
+
+
+@contextmanager
 def mlflow_run(
     config: MLflowConfig,
     *,
@@ -82,11 +111,15 @@ def mlflow_run(
         **dict(config.tags or {}),
     }
     with mlflow.start_run(run_name=config.run_name, tags=tags):
-        mlflow.log_params(
-            {
-                "pattern": pattern,
-                "topic": topic,
-                "config_path": config_path,
-            }
-        )
-        yield MLflowRun(mlflow)
+        tracing_token = _tracing_enabled.set(True)
+        try:
+            mlflow.log_params(
+                {
+                    "pattern": pattern,
+                    "topic": topic,
+                    "config_path": config_path,
+                }
+            )
+            yield MLflowRun(mlflow)
+        finally:
+            _tracing_enabled.reset(tracing_token)

--- a/awesome_dspy_agents/patterns/addition_by_subtraction/pattern.py
+++ b/awesome_dspy_agents/patterns/addition_by_subtraction/pattern.py
@@ -6,6 +6,7 @@ import dspy  # type: ignore
 
 from awesome_dspy_agents.config import AppConfig, build_lm, load_config
 from awesome_dspy_agents.logging_setup import get_logger
+from awesome_dspy_agents.mlflow_integration import mlflow_span
 from awesome_dspy_agents.patterns.interface import AgentPattern
 from awesome_dspy_agents.predictor import build_predictor
 from awesome_dspy_agents.runtime import (
@@ -175,17 +176,70 @@ class ABSFramework(dspy.Module):
             iter_token = set_current_iteration(iteration)
             try:
                 # Addition produces candidate
-                add_out = self.addition(
-                    context=H_context, instruction=H_instruction, history=hist_str
-                )
+                with mlflow_span(
+                    "agent.addition",
+                    span_type="AGENT",
+                    inputs={
+                        "context": H_context,
+                        "instruction": H_instruction,
+                        "history": hist_str,
+                    },
+                    attributes={
+                        "agent.pattern": "addition_by_subtraction",
+                        "agent.role": "addition",
+                        "agent.iteration": iteration,
+                        "agent.module_type": getattr(
+                            self.addition, "module_type", "unknown"
+                        ),
+                        "agent.answer_owner": False,
+                    },
+                ) as span:
+                    add_out = self.addition(
+                        context=H_context,
+                        instruction=H_instruction,
+                        history=hist_str,
+                    )
+                    if span is not None:
+                        span.set_outputs(
+                            {
+                                "candidate_response": add_out.candidate_response,
+                                "reasoning": add_out.reasoning,
+                            }
+                        )
 
                 # Subtraction refines
-                sub_out = self.subtraction(
-                    context=H_context,
-                    instruction=H_instruction,
-                    history=hist_str,
-                    candidate_response=add_out.candidate_response,
-                )
+                with mlflow_span(
+                    "agent.subtraction",
+                    span_type="AGENT",
+                    inputs={
+                        "context": H_context,
+                        "instruction": H_instruction,
+                        "history": hist_str,
+                        "candidate_response": add_out.candidate_response,
+                    },
+                    attributes={
+                        "agent.pattern": "addition_by_subtraction",
+                        "agent.role": "subtraction",
+                        "agent.iteration": iteration,
+                        "agent.module_type": getattr(
+                            self.subtraction, "module_type", "unknown"
+                        ),
+                        "agent.answer_owner": True,
+                    },
+                ) as span:
+                    sub_out = self.subtraction(
+                        context=H_context,
+                        instruction=H_instruction,
+                        history=hist_str,
+                        candidate_response=add_out.candidate_response,
+                    )
+                    if span is not None:
+                        span.set_outputs(
+                            {
+                                "refined_response": sub_out.refined_response,
+                                "feedback": sub_out.feedback,
+                            }
+                        )
 
                 exchange = AdditionBySubtractionExchange(
                     addition=add_out.candidate_response,

--- a/awesome_dspy_agents/patterns/debate/pattern.py
+++ b/awesome_dspy_agents/patterns/debate/pattern.py
@@ -6,6 +6,7 @@ import dspy  # type: ignore
 
 from awesome_dspy_agents.config import AppConfig, build_lm, load_config
 from awesome_dspy_agents.logging_setup import get_logger
+from awesome_dspy_agents.mlflow_integration import mlflow_span
 from awesome_dspy_agents.patterns.interface import AgentPattern
 from awesome_dspy_agents.predictor import build_predictor
 from awesome_dspy_agents.runtime import (
@@ -288,17 +289,66 @@ class MADFramework(dspy.Module):
             iter_token = set_current_iteration(iteration)
             try:
                 # Affirmative speaks
-                aff_response = self.affirmative(
-                    debate_topic=debate_topic,
-                    debate_history=history_str,
-                )
+                with mlflow_span(
+                    "agent.affirmative",
+                    span_type="AGENT",
+                    inputs={
+                        "debate_topic": debate_topic,
+                        "debate_history": history_str,
+                    },
+                    attributes={
+                        "agent.pattern": "debate",
+                        "agent.role": "affirmative",
+                        "agent.iteration": iteration,
+                        "agent.module_type": getattr(
+                            self.affirmative, "module_type", "unknown"
+                        ),
+                        "agent.answer_owner": False,
+                    },
+                ) as span:
+                    aff_response = self.affirmative(
+                        debate_topic=debate_topic,
+                        debate_history=history_str,
+                    )
+                    if span is not None:
+                        span.set_outputs(
+                            {
+                                "argument": aff_response.argument,
+                                "reasoning": aff_response.reasoning,
+                            }
+                        )
 
                 # Negative responds
-                neg_response = self.negative(
-                    debate_topic=debate_topic,
-                    debate_history=history_str,
-                    affirmative_argument=aff_response.argument,
-                )
+                with mlflow_span(
+                    "agent.negative",
+                    span_type="AGENT",
+                    inputs={
+                        "debate_topic": debate_topic,
+                        "debate_history": history_str,
+                        "affirmative_argument": aff_response.argument,
+                    },
+                    attributes={
+                        "agent.pattern": "debate",
+                        "agent.role": "negative",
+                        "agent.iteration": iteration,
+                        "agent.module_type": getattr(
+                            self.negative, "module_type", "unknown"
+                        ),
+                        "agent.answer_owner": False,
+                    },
+                ) as span:
+                    neg_response = self.negative(
+                        debate_topic=debate_topic,
+                        debate_history=history_str,
+                        affirmative_argument=aff_response.argument,
+                    )
+                    if span is not None:
+                        span.set_outputs(
+                            {
+                                "counter_argument": neg_response.counter_argument,
+                                "reasoning": neg_response.reasoning,
+                            }
+                        )
 
                 # Record exchange
                 exchange = DebateExchange(
@@ -320,11 +370,38 @@ class MADFramework(dspy.Module):
                 # Judge evaluates
                 if self.adaptive_break:
                     history_str = self.format_history(history)
-                    judge_eval = self.judge.evaluate_debate(
-                        debate_topic=debate_topic,
-                        debate_history=history_str,
-                        current_iteration=iteration,
-                    )
+                    with mlflow_span(
+                        "agent.judge.evaluate",
+                        span_type="AGENT",
+                        inputs={
+                            "debate_topic": debate_topic,
+                            "debate_history": history_str,
+                            "current_iteration": iteration,
+                        },
+                        attributes={
+                            "agent.pattern": "debate",
+                            "agent.role": "judge",
+                            "agent.operation": "evaluate",
+                            "agent.iteration": iteration,
+                            "agent.module_type": getattr(
+                                self.judge, "module_type", "unknown"
+                            ),
+                            "agent.answer_owner": False,
+                        },
+                    ) as span:
+                        judge_eval = self.judge.evaluate_debate(
+                            debate_topic=debate_topic,
+                            debate_history=history_str,
+                            current_iteration=iteration,
+                        )
+                        if span is not None:
+                            span.set_outputs(
+                                {
+                                    "solution_found": judge_eval.solution_found,
+                                    "confidence": judge_eval.confidence,
+                                    "reasoning": judge_eval.reasoning,
+                                }
+                            )
 
                     exchange = replace(exchange, judge_eval=judge_eval.reasoning)
                     history[-1] = exchange
@@ -339,10 +416,35 @@ class MADFramework(dspy.Module):
 
                     if judge_eval.solution_found and judge_eval.confidence > 0.7:
                         solution_found = True
-                        final_answer = self.judge.extract_solution(
-                            debate_topic=debate_topic,
-                            debate_history=history_str,
-                        )
+                        with mlflow_span(
+                            "agent.judge.final_answer",
+                            span_type="AGENT",
+                            inputs={
+                                "debate_topic": debate_topic,
+                                "debate_history": history_str,
+                            },
+                            attributes={
+                                "agent.pattern": "debate",
+                                "agent.role": "judge",
+                                "agent.operation": "extract_final_answer",
+                                "agent.iteration": iteration,
+                                "agent.module_type": getattr(
+                                    self.judge, "module_type", "unknown"
+                                ),
+                                "agent.answer_owner": True,
+                            },
+                        ) as span:
+                            final_answer = self.judge.extract_solution(
+                                debate_topic=debate_topic,
+                                debate_history=history_str,
+                            )
+                            if span is not None:
+                                span.set_outputs(
+                                    {
+                                        "final_answer": final_answer.final_answer,
+                                        "justification": final_answer.justification,
+                                    }
+                                )
                         break
             finally:
                 reset_current_iteration(iter_token)
@@ -350,10 +452,35 @@ class MADFramework(dspy.Module):
         # Extract final answer if not found adaptively
         if not solution_found:
             history_str = self.format_history(history)
-            final_prediction = self.judge.extract_solution(
-                debate_topic=debate_topic,
-                debate_history=history_str,
-            )
+            with mlflow_span(
+                "agent.judge.final_answer",
+                span_type="AGENT",
+                inputs={
+                    "debate_topic": debate_topic,
+                    "debate_history": history_str,
+                },
+                attributes={
+                    "agent.pattern": "debate",
+                    "agent.role": "judge",
+                    "agent.operation": "extract_final_answer",
+                    "agent.iteration": len(history),
+                    "agent.module_type": getattr(
+                        self.judge, "module_type", "unknown"
+                    ),
+                    "agent.answer_owner": True,
+                },
+            ) as span:
+                final_prediction = self.judge.extract_solution(
+                    debate_topic=debate_topic,
+                    debate_history=history_str,
+                )
+                if span is not None:
+                    span.set_outputs(
+                        {
+                            "final_answer": final_prediction.final_answer,
+                            "justification": final_prediction.justification,
+                        }
+                    )
             final_answer = final_prediction
 
         if final_answer is None:

--- a/awesome_dspy_agents/patterns/debate/pattern.py
+++ b/awesome_dspy_agents/patterns/debate/pattern.py
@@ -464,9 +464,7 @@ class MADFramework(dspy.Module):
                     "agent.role": "judge",
                     "agent.operation": "extract_final_answer",
                     "agent.iteration": len(history),
-                    "agent.module_type": getattr(
-                        self.judge, "module_type", "unknown"
-                    ),
+                    "agent.module_type": getattr(self.judge, "module_type", "unknown"),
                     "agent.answer_owner": True,
                 },
             ) as span:

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -91,9 +91,7 @@ class MLflowIntegrationTests(unittest.TestCase):
             span_type=mlflow.entities.SpanType.AGENT,
         )
         span.set_inputs.assert_called_once_with({"topic": "Topic"})
-        span.set_attributes.assert_called_once_with(
-            {"agent.role": "affirmative"}
-        )
+        span.set_attributes.assert_called_once_with({"agent.role": "affirmative"})
         span.set_outputs.assert_called_once_with({"argument": "Answer"})
 
     def test_span_is_noop_outside_enabled_run(self) -> None:

--- a/tests/test_mlflow_integration.py
+++ b/tests/test_mlflow_integration.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import unittest
 from unittest.mock import MagicMock, patch
 
-from awesome_dspy_agents.mlflow_integration import MLflowConfig, mlflow_run
+from awesome_dspy_agents.mlflow_integration import (
+    MLflowConfig,
+    mlflow_run,
+    mlflow_span,
+)
 
 
 class MLflowIntegrationTests(unittest.TestCase):
@@ -23,6 +27,8 @@ class MLflowIntegrationTests(unittest.TestCase):
     def test_enabled_integration_configures_and_logs_run(self) -> None:
         mlflow = MagicMock()
         mlflow.start_run.return_value.__enter__.return_value = MagicMock()
+        span = MagicMock()
+        mlflow.start_span.return_value.__enter__.return_value = span
         config = MLflowConfig(
             enabled=True,
             tracking_uri="http://localhost:5000",
@@ -40,6 +46,14 @@ class MLflowIntegrationTests(unittest.TestCase):
                 version="1.0",
             ) as run:
                 assert run is not None
+                with mlflow_span(
+                    "agent.affirmative",
+                    span_type="AGENT",
+                    inputs={"topic": "Topic"},
+                    attributes={"agent.role": "affirmative"},
+                ) as active_span:
+                    self.assertIs(active_span, span)
+                    active_span.set_outputs({"argument": "Answer"})
                 run.log_outcome(
                     {
                         "result": {
@@ -72,6 +86,22 @@ class MLflowIntegrationTests(unittest.TestCase):
             }
         )
         mlflow.log_dict.assert_called_once()
+        mlflow.start_span.assert_called_once_with(
+            name="agent.affirmative",
+            span_type=mlflow.entities.SpanType.AGENT,
+        )
+        span.set_inputs.assert_called_once_with({"topic": "Topic"})
+        span.set_attributes.assert_called_once_with(
+            {"agent.role": "affirmative"}
+        )
+        span.set_outputs.assert_called_once_with({"argument": "Answer"})
+
+    def test_span_is_noop_outside_enabled_run(self) -> None:
+        with patch("importlib.import_module") as import_module:
+            with mlflow_span("agent", span_type="AGENT") as span:
+                self.assertIsNone(span)
+
+        import_module.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a root CHAIN span for each pattern execution
- add named AGENT spans for debate and addition-by-subtraction participants
- attach role, iteration, module type, inputs, outputs, and answer-owner metadata
- keep DSPy autologged parser and model spans nested beneath the responsible agent
- keep tracing optional and a no-op when MLflow is disabled
- document the trace hierarchy in the MLflow observability section

## Validation

- 35 tests passed on the isolated commit
- Ruff passed
- Pyrefly passed with 0 errors
- manually verified 10 RAMDocs traces in MLflow 3.14 using debate and addition-by-subtraction patterns

## Notes

Generated datasets, run artifacts, caches, and experiment-specific Qwen configuration are intentionally excluded.