### PR TITLE
feat: add reusable deliberation and consensus-free debate patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A collection of multi-agent systems implemented with the [DSPy](https://github.c
   - [Using the CLI](#using-the-cli)
   - [Configuration](#configuration)
   - [Examples](#examples)
+    - [Debate Protocols](#debate-protocols)
     - [Addition-by-Subtraction Pattern](#addition-by-subtraction-pattern)
   - [Development Guide](#development-guide)
     - [Project layout](#project-layout)
@@ -84,15 +85,18 @@ These are the built-in patterns. Use the CLI to explore and run them.
 
 | Pattern | Description | Strengths | Weaknesses |
 | --- | --- | --- | --- |
-| debate | Multi‑Agent Debate with a Judge. Two agents argue iteratively; an optional judge evaluates progress and extracts the final answer. | Strong adversarial reasoning; adaptive early stop; ReAct tool support. | Higher token usage; needs careful judge configuration. |
-| addition_by_subtraction | Addition‑by‑Subtraction collaboration. Addition expands details; Subtraction removes redundancy and feeds back; early exit when stable. | Concise refined answers; low iteration count by default (M≤2); ReAct tool support. | Can miss alternative directions; relies on good subtraction feedback. |
+| debate | Multi-Agent Debate with classic adversarial and consensus-free protocols. | Independent proposals, selective conflict routing, full-trajectory arbitration, adaptive classic mode, and ReAct tools. | More calls than a single predictor; arbitration and role configuration affect quality. |
+| addition_by_subtraction | Addition expands the latest response; Subtraction records removals, reasons, preserved facts, and feedback. | Inspectable refinement, concise answers, early exit, and ReAct tools. | Can miss alternative directions; relies on useful subtraction feedback. |
 
 Related work:
-#### Debates 
-Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate: https://arxiv.org/abs/2305.19118
+#### Debates
+
+- [Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate](https://arxiv.org/abs/2305.19118)
+- [Free-MAD: Consensus-Free Multi-Agent Debate](https://arxiv.org/abs/2509.11035)
 
 #### Addition by Subtraction
-(Perhaps) Beyond Human Translation: Harnessing Multi-Agent Collaboration for Translating Ultra-Long Literary Texts: https://arxiv.org/abs/2305.19118
+
+- [(Perhaps) Beyond Human Translation: Harnessing Multi-Agent Collaboration for Translating Ultra-Long Literary Texts](https://arxiv.org/abs/2405.11804)
 
 ### Available Tools
 
@@ -149,6 +153,11 @@ poetry run dspy-agents run debate "Is RLHF always beneficial?"
 
 # custom config
 poetry run dspy-agents run debate -c awesome_dspy_agents/patterns/debate/config.yaml "Debate topic"
+
+# consensus-free scenario: independent proposals, selective revision, arbitration
+poetry run dspy-agents run debate \
+  -c awesome_dspy_agents/patterns/debate/scenarios/consensus_free.yaml \
+  "Which conclusion is best supported?"
 
 # override nested config values at runtime (typed casting: bool/int/float)
 poetry run dspy-agents run debate "Topic" --set debate.max_iterations=3 --set debate.debate_level=2 --set judge.module_type=react
@@ -240,9 +249,31 @@ judge:
   tools: ["write_file"]
 
 debate:
+  protocol: classic_adversarial
   max_iterations: 5
   debate_level: 2
   adaptive_break: true
+```
+
+Use the included scenario for consensus-free debate, or configure it directly:
+
+```yaml
+debate:
+  protocol: consensus_free
+  agent_count: 2
+  perspectives:
+    - Focus on direct evidence and check assumptions.
+    - Search for counterexamples and alternative explanations.
+
+agents:
+  proposer:
+    module_type: predict
+  conflict_selector:
+    module_type: predict
+  reviser:
+    module_type: predict
+  arbiter:
+    module_type: predict
 ```
 
 ```yaml
@@ -271,11 +302,49 @@ Tips:
 
 - Point to a custom config: `-c path/to/config.yaml`.
 - OpenRouter DeepSeek profile: `examples/configs/openrouter-deepseek-v4-flash.yaml`.
+- Debate protocol: set `debate.protocol` to `classic_adversarial` or `consensus_free`.
+- Consensus-free diversity: set `debate.agent_count` and one `perspectives` entry per agent.
 - Override nested values at runtime (typed): `--set debate.max_iterations=3 --set judge.module_type=react`.
 - Per‑agent LM: set `agents.<name>.lm` block with `provider/model/api_base/api_key(_env)`.
 - File tools are sandboxed; add `--allow-path /abs/dir` to enable local file access.
 
 ## Examples
+
+### Debate Protocols
+
+Classic adversarial debate keeps the affirmative/negative exchange and optional
+confidence-based early stop. It remains the default for backward compatibility.
+
+Consensus-free debate uses this sequence:
+
+1. Generate independent proposals without peer history.
+2. Select and route consequential conflicts anonymously.
+3. Revise without treating majority agreement as evidence.
+4. Score every candidate and arbitrate over the complete trajectory.
+
+If no meaningful conflict is found, revision is skipped and the independent
+proposals go directly to arbitration.
+
+```bash
+poetry run dspy-agents run debate \
+  -c awesome_dspy_agents/patterns/debate/scenarios/consensus_free.yaml \
+  "Evaluate the evidence and choose the best-supported answer"
+```
+
+Each optimizable role remains a named DSPy predictor, so GEPA can improve the
+proposer, conflict selector, reviser, and arbiter instructions together:
+
+```python
+from awesome_dspy_agents.patterns.debate import ConsensusFreeDebate
+
+program = ConsensusFreeDebate(agent_count=2)
+for name, predictor in program.named_predictors():
+    print(name, predictor.signature.instructions)
+```
+
+Both protocols return an immutable trajectory. Events retain causal parents,
+claims, evidence IDs, revisions, and tool observations while role-specific views
+control what each agent sees.
 
 Run Debate with a custom judge and fewer iterations:
 
@@ -302,7 +371,13 @@ poetry run dspy-agents run addition_by_subtraction "Summarize the attached doc" 
 
 ### Addition-by-Subtraction Pattern
 
-This collaboration uses two agents only: Addition (expands and aggregates relevant details) and Subtraction (removes redundancy and provides feedback). It iterates up to `abs.max_iterations` with an early-exit when no further revision is needed.
+This collaboration uses two agents. Addition expands the latest refined response;
+Subtraction removes harmful or redundant material and returns feedback for the
+next round.
+
+The result includes a structured ledger of additions, removals, removal reasons,
+and preserved facts. It iterates up to `abs.max_iterations` and exits early when
+the refined response stops changing.
 
 - Default config: `awesome_dspy_agents/patterns/addition_by_subtraction/config.yaml`
 - Supports tools via ReAct (same registry as debate). Tools used are rendered in TUI under each iteration.
@@ -355,10 +430,16 @@ awesome_dspy_agents/
     ascii_to_png.py            # Example image tool
   patterns/
     interface.py               # AgentPattern protocol and discovery
+    deliberation/
+      trajectory.py            # Immutable events, deltas, evidence, and views
     debate/
-      pattern.py               # DebatePattern + MADFramework
+      pattern.py               # Runtime adapter + classic MADFramework
       signatures.py            # DSPy signatures
+      consensus_free.py        # Consensus-free protocol orchestration
+      consensus_free_signatures.py
       config.yaml              # Default config
+      scenarios/
+        consensus_free.yaml    # Ready-to-run modern debate preset
     addition_by_subtraction/
       pattern.py               # Addition-by-Subtraction Pattern + ABSFramework
       signatures.py            # DSPy signatures

--- a/awesome_dspy_agents/config.py
+++ b/awesome_dspy_agents/config.py
@@ -61,6 +61,9 @@ class JudgeConfig(BaseModel):
 class DebateConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    protocol: Literal["classic_adversarial", "consensus_free"] = "classic_adversarial"
+    agent_count: int = Field(default=2, ge=2)
+    perspectives: list[str] | None = None
     max_iterations: int = Field(default=3, ge=1)
     debate_level: int = Field(default=2, ge=0, le=3)
     adaptive_break: bool = True

--- a/awesome_dspy_agents/patterns/addition_by_subtraction/README.md
+++ b/awesome_dspy_agents/patterns/addition_by_subtraction/README.md
@@ -1,0 +1,28 @@
+# Addition by Subtraction
+
+Addition by Subtraction is an asymmetric refinement protocol. The addition role
+expands the latest refined response; the subtraction role removes redundancy,
+unsupported claims, and irrelevant material while preserving the instruction and
+supported facts.
+
+Each round carries explicit state forward:
+
+```text
+current refined response + previous feedback
+  -> additions + candidate response
+  -> removals + preserved facts + refined response + next feedback
+```
+
+The framework still returns its backward-compatible typed exchange history. It
+also returns an immutable `trajectory` containing proposal and revision events,
+their causal links, and the claims preserved at each step.
+
+```python
+from awesome_dspy_agents.patterns.addition_by_subtraction.pattern import ABSFramework
+
+refiner = ABSFramework(max_iterations=2)
+result = refiner(context=source_material, instruction="Write a concise answer")
+
+print(result.final_answer)
+print(result.stop_reason)
+```

--- a/awesome_dspy_agents/patterns/addition_by_subtraction/pattern.py
+++ b/awesome_dspy_agents/patterns/addition_by_subtraction/pattern.py
@@ -7,7 +7,10 @@ import dspy  # type: ignore
 from awesome_dspy_agents.config import AppConfig, build_lm, load_config
 from awesome_dspy_agents.logging_setup import get_logger
 from awesome_dspy_agents.mlflow_integration import mlflow_span
-from awesome_dspy_agents.patterns.deliberation import DeliberationTrajectory
+from awesome_dspy_agents.patterns.deliberation import (
+    DeliberationDelta,
+    DeliberationTrajectory,
+)
 from awesome_dspy_agents.patterns.interface import AgentPattern
 from awesome_dspy_agents.predictor import build_predictor
 from awesome_dspy_agents.runtime import (
@@ -33,6 +36,10 @@ class AdditionBySubtractionExchange:
     addition_reasoning: str
     subtraction: str
     feedback: str
+    additions: tuple[str, ...] = ()
+    removals: tuple[str, ...] = ()
+    removal_reasons: tuple[str, ...] = ()
+    preserved_facts: tuple[str, ...] = ()
 
 
 class AdditionModule(dspy.Module):
@@ -229,6 +236,9 @@ class ABSFramework(dspy.Module):
                     content=add_out.candidate_response,
                     reasoning=add_out.reasoning,
                     claims=tuple(getattr(add_out, "additions", [])),
+                    delta=DeliberationDelta(
+                        added=tuple(getattr(add_out, "additions", []))
+                    ),
                 )
                 addition_event_id = trajectory.events[-1].event_id
 
@@ -273,6 +283,11 @@ class ABSFramework(dspy.Module):
                     content=sub_out.refined_response,
                     reasoning=sub_out.feedback,
                     claims=tuple(getattr(sub_out, "preserved_facts", [])),
+                    delta=DeliberationDelta(
+                        removed=tuple(getattr(sub_out, "removals", [])),
+                        removal_reasons=tuple(getattr(sub_out, "removal_reasons", [])),
+                        preserved=tuple(getattr(sub_out, "preserved_facts", [])),
+                    ),
                     parent_ids=(addition_event_id,),
                 )
 
@@ -281,6 +296,10 @@ class ABSFramework(dspy.Module):
                     addition_reasoning=add_out.reasoning,
                     subtraction=sub_out.refined_response,
                     feedback=sub_out.feedback,
+                    additions=tuple(getattr(add_out, "additions", [])),
+                    removals=tuple(getattr(sub_out, "removals", [])),
+                    removal_reasons=tuple(getattr(sub_out, "removal_reasons", [])),
+                    preserved_facts=tuple(getattr(sub_out, "preserved_facts", [])),
                 )
                 history.append(exchange)
 

--- a/awesome_dspy_agents/patterns/addition_by_subtraction/pattern.py
+++ b/awesome_dspy_agents/patterns/addition_by_subtraction/pattern.py
@@ -7,6 +7,7 @@ import dspy  # type: ignore
 from awesome_dspy_agents.config import AppConfig, build_lm, load_config
 from awesome_dspy_agents.logging_setup import get_logger
 from awesome_dspy_agents.mlflow_integration import mlflow_span
+from awesome_dspy_agents.patterns.deliberation import DeliberationTrajectory
 from awesome_dspy_agents.patterns.interface import AgentPattern
 from awesome_dspy_agents.predictor import build_predictor
 from awesome_dspy_agents.runtime import (
@@ -56,7 +57,14 @@ class AdditionModule(dspy.Module):
             react_max_iters=react_max_iters,
         )
 
-    def forward(self, context: str, instruction: str, history: str):
+    def forward(
+        self,
+        context: str,
+        instruction: str,
+        history: str = "",
+        current_response: str = "",
+        previous_feedback: str = "",
+    ):
         llm_logger.info(
             "predict",
             role="addition",
@@ -67,7 +75,8 @@ class AdditionModule(dspy.Module):
         return self.predict(
             context=context,
             instruction=instruction,
-            history=history,
+            current_response=current_response,
+            previous_feedback=previous_feedback,
             persona=self.persona,
         )
 
@@ -107,8 +116,8 @@ class SubtractionModule(dspy.Module):
         return self.predict(
             context=context,
             instruction=instruction,
-            history=history,
             candidate_response=candidate_response,
+            preservation_requirements=instruction,
             persona=self.persona,
         )
 
@@ -165,14 +174,16 @@ class ABSFramework(dspy.Module):
 
     def forward(self, context: str, instruction: str):
         history: list[AdditionBySubtractionExchange] = []
+        trajectory = DeliberationTrajectory()
         final_response = ""
 
         H_context = context
         H_instruction = instruction
 
         previous_refined_response: str | None = None
+        previous_feedback = ""
         for iteration in range(1, self.max_iterations + 1):
-            hist_str = self.format_history(history)
+            hist_str = trajectory.render()
             iter_token = set_current_iteration(iteration)
             try:
                 # Addition produces candidate
@@ -183,6 +194,8 @@ class ABSFramework(dspy.Module):
                         "context": H_context,
                         "instruction": H_instruction,
                         "history": hist_str,
+                        "current_response": previous_refined_response or "",
+                        "previous_feedback": previous_feedback,
                     },
                     attributes={
                         "agent.pattern": "addition_by_subtraction",
@@ -198,6 +211,8 @@ class ABSFramework(dspy.Module):
                         context=H_context,
                         instruction=H_instruction,
                         history=hist_str,
+                        current_response=previous_refined_response or "",
+                        previous_feedback=previous_feedback,
                     )
                     if span is not None:
                         span.set_outputs(
@@ -206,6 +221,16 @@ class ABSFramework(dspy.Module):
                                 "reasoning": add_out.reasoning,
                             }
                         )
+
+                trajectory = trajectory.record(
+                    round_index=iteration,
+                    role="addition",
+                    kind="proposal",
+                    content=add_out.candidate_response,
+                    reasoning=add_out.reasoning,
+                    claims=tuple(getattr(add_out, "additions", [])),
+                )
+                addition_event_id = trajectory.events[-1].event_id
 
                 # Subtraction refines
                 with mlflow_span(
@@ -241,6 +266,16 @@ class ABSFramework(dspy.Module):
                             }
                         )
 
+                trajectory = trajectory.record(
+                    round_index=iteration,
+                    role="subtraction",
+                    kind="revision",
+                    content=sub_out.refined_response,
+                    reasoning=sub_out.feedback,
+                    claims=tuple(getattr(sub_out, "preserved_facts", [])),
+                    parent_ids=(addition_event_id,),
+                )
+
                 exchange = AdditionBySubtractionExchange(
                     addition=add_out.candidate_response,
                     addition_reasoning=add_out.reasoning,
@@ -268,6 +303,7 @@ class ABSFramework(dspy.Module):
                     break
 
                 previous_refined_response = sub_out.refined_response
+                previous_feedback = sub_out.feedback
                 H_context = context
                 H_instruction = instruction
             finally:
@@ -281,8 +317,14 @@ class ABSFramework(dspy.Module):
             final_answer=final_response,
             justification="Refined via Addition-by-Subtraction iterative collaboration.",
             history=history,
+            trajectory=trajectory,
             iterations_used=len(history),
             stopped_early=self.early_exit and len(history) < self.max_iterations,
+            stop_reason=(
+                "unchanged"
+                if self.early_exit and len(history) < self.max_iterations
+                else "iteration_budget"
+            ),
         )
 
 

--- a/awesome_dspy_agents/patterns/addition_by_subtraction/signatures.py
+++ b/awesome_dspy_agents/patterns/addition_by_subtraction/signatures.py
@@ -2,25 +2,42 @@ import dspy  # type: ignore
 
 
 class AdditionAgentSignature(dspy.Signature):
-    """Addition agent produces a comprehensive candidate response."""
+    """Add useful material to the current response without restarting it."""
 
     context: str = dspy.InputField(desc="Context C")
     instruction: str = dspy.InputField(desc="Instruction I")
-    history: str = dspy.InputField(desc="Conversation history H")
+    current_response: str = dspy.InputField(desc="Latest refined response")
+    previous_feedback: str = dspy.InputField(
+        desc="Specific feedback from the previous subtraction"
+    )
     persona: str = dspy.InputField(desc="Persona influencing tone and style")
 
+    additions: list[str] = dspy.OutputField(
+        desc="Material added to satisfy the instruction or feedback"
+    )
     candidate_response: str = dspy.OutputField(desc="Detailed candidate response R'")
-    reasoning: str = dspy.OutputField(desc="Step-by-step reasoning for additions")
+    reasoning: str = dspy.OutputField(desc="Concise rationale for the additions")
 
 
 class SubtractionAgentSignature(dspy.Signature):
-    """Subtraction agent removes redundancies and provides feedback."""
+    """Remove harmful material while preserving supported facts and constraints."""
 
     context: str = dspy.InputField(desc="Context C")
     instruction: str = dspy.InputField(desc="Instruction I")
-    history: str = dspy.InputField(desc="Conversation history H including latest R'")
     candidate_response: str = dspy.InputField(desc="Latest candidate response R'")
+    preservation_requirements: str = dspy.InputField(
+        desc="Instruction and constraints that subtraction must preserve"
+    )
     persona: str = dspy.InputField(desc="Persona influencing tone and style")
 
+    removals: list[str] = dspy.OutputField(
+        desc="Redundant, unsupported, irrelevant, or harmful material removed"
+    )
+    removal_reasons: list[str] = dspy.OutputField(
+        desc="Reason corresponding to each removal"
+    )
+    preserved_facts: list[str] = dspy.OutputField(
+        desc="Important supported facts explicitly preserved"
+    )
     refined_response: str = dspy.OutputField(desc="Concise response after subtraction")
     feedback: str = dspy.OutputField(desc="Feedback to guide the next addition step")

--- a/awesome_dspy_agents/patterns/debate/README.md
+++ b/awesome_dspy_agents/patterns/debate/README.md
@@ -1,0 +1,44 @@
+# Multi-Agent Debate
+
+The debate pattern provides two protocols over a shared immutable deliberation
+trajectory.
+
+- `ClassicAdversarialDebate` preserves the sequential affirmative/negative
+  protocol.
+- `ConsensusFreeDebate` runs independent proposals, selects consequential
+  conflicts, performs anti-conformity revisions, and arbitrates over the full
+  trajectory.
+
+The consensus-free protocol deliberately does not ask agents to reach agreement
+or vote over the last round. Initial proposals never contain peer history,
+revisers receive only selected anonymous disagreements, and the arbiter receives
+the complete trajectory.
+
+```python
+from awesome_dspy_agents.patterns.debate import ConsensusFreeDebate
+
+debate = ConsensusFreeDebate(agent_count=2)
+result = debate(problem="Which conclusion is best supported?", context=evidence)
+
+print(result.final_answer)
+for event in result.trajectory.events:
+    print(event.event_id, event.kind, event.parent_ids)
+```
+
+Every optimizable role is a named DSPy predictor:
+
+```python
+for name, predictor in debate.named_predictors():
+    print(name, predictor.signature.instructions)
+```
+
+This allows GEPA to optimize proposer, conflict-selector, reviser, and arbiter
+instructions as parts of one DSPy program. The scenario
+`scenarios/consensus_free.yaml` selects this protocol through the normal pattern
+runtime.
+
+## History policy
+
+The trajectory is the source of truth. A history view decides which immutable
+events an agent sees and whether roles or reasoning are revealed. Evidence IDs
+remain attached to events even when agent identity is hidden.

--- a/awesome_dspy_agents/patterns/debate/README.md
+++ b/awesome_dspy_agents/patterns/debate/README.md
@@ -40,6 +40,15 @@ result = debate(
 )
 ```
 
+When a configured ReAct role calls a runtime tool, its result is also captured
+automatically as a `tool_observation` event and linked to that role's proposal,
+conflict, revision, or judgment. The normal external tool telemetry remains
+metadata-only; result content is scoped to the deliberation trajectory.
+
+If the conflict selector finds no meaningful disagreement, revision is skipped
+and the independent proposals go directly to arbitration. Otherwise, every
+candidate must receive an explicit arbiter score before a result is returned.
+
 Every optimizable role is a named DSPy predictor:
 
 ```python

--- a/awesome_dspy_agents/patterns/debate/README.md
+++ b/awesome_dspy_agents/patterns/debate/README.md
@@ -25,6 +25,21 @@ for event in result.trajectory.events:
     print(event.event_id, event.kind, event.parent_ids)
 ```
 
+Documents and tool outputs can be supplied with stable provenance IDs. References
+invented by a model are not attached to proposal events:
+
+```python
+from awesome_dspy_agents.patterns.deliberation import EvidenceArtifact
+
+result = debate(
+    problem="Which conclusion is best supported?",
+    evidence=(
+        EvidenceArtifact("document-1", document_text),
+        EvidenceArtifact("tool-1", tool_output, kind="tool"),
+    ),
+)
+```
+
 Every optimizable role is a named DSPy predictor:
 
 ```python

--- a/awesome_dspy_agents/patterns/debate/__init__.py
+++ b/awesome_dspy_agents/patterns/debate/__init__.py
@@ -1,0 +1,10 @@
+from .consensus_free import ConsensusFreeDebate
+from .pattern import MADFramework
+
+ClassicAdversarialDebate = MADFramework
+
+__all__ = [
+    "ClassicAdversarialDebate",
+    "ConsensusFreeDebate",
+    "MADFramework",
+]

--- a/awesome_dspy_agents/patterns/debate/consensus_free.py
+++ b/awesome_dspy_agents/patterns/debate/consensus_free.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import dspy
+
+from awesome_dspy_agents.patterns.deliberation import (
+    DeliberationTrajectory,
+    HistoryView,
+)
+from awesome_dspy_agents.predictor import build_predictor
+from awesome_dspy_agents.runtime import EmitIteration, IterationEvent
+
+from .consensus_free_signatures import (
+    ArbitrateFullTrajectory,
+    IndependentProposal,
+    ReviseWithoutConformity,
+    SelectConflicts,
+)
+
+
+@dataclass(frozen=True)
+class ConsensusFreeDebateRound:
+    proposal_ids: tuple[str, ...]
+    revision_ids: tuple[str, ...]
+    conflicts: tuple[str, ...]
+
+
+class ConsensusFreeDebate(dspy.Module):
+    """Independent proposals, anti-conformity revision, and trajectory arbitration."""
+
+    def __init__(
+        self,
+        *,
+        agent_count: int = 2,
+        perspectives: Sequence[str] | None = None,
+        proposer_module_type: str = "predict",
+        conflict_selector_module_type: str = "predict",
+        reviser_module_type: str = "predict",
+        arbiter_module_type: str = "predict",
+        proposer_lm: dspy.LM | None = None,
+        conflict_selector_lm: dspy.LM | None = None,
+        reviser_lm: dspy.LM | None = None,
+        arbiter_lm: dspy.LM | None = None,
+        proposer_tools: Sequence[str] | None = None,
+        conflict_selector_tools: Sequence[str] | None = None,
+        reviser_tools: Sequence[str] | None = None,
+        arbiter_tools: Sequence[str] | None = None,
+        react_max_iters: int = 6,
+        on_iteration: EmitIteration | None = None,
+    ) -> None:
+        super().__init__()
+        if agent_count < 2:
+            raise ValueError("Consensus-free debate requires at least two agents")
+        if perspectives is not None and len(perspectives) != agent_count:
+            raise ValueError("perspectives must contain one value per agent")
+
+        self.agent_count = agent_count
+        self.on_iteration = on_iteration
+        self.perspectives = tuple(
+            perspectives
+            or (
+                f"independent perspective {index}"
+                for index in range(1, agent_count + 1)
+            )
+        )
+        self.proposer = build_predictor(
+            IndependentProposal,
+            proposer_module_type,
+            role="proposer",
+            lm=proposer_lm,
+            tool_names=proposer_tools,
+            react_max_iters=react_max_iters,
+        )
+        self.conflict_selector = build_predictor(
+            SelectConflicts,
+            conflict_selector_module_type,
+            role="conflict_selector",
+            lm=conflict_selector_lm,
+            tool_names=conflict_selector_tools,
+            react_max_iters=react_max_iters,
+        )
+        self.reviser = build_predictor(
+            ReviseWithoutConformity,
+            reviser_module_type,
+            role="reviser",
+            lm=reviser_lm,
+            tool_names=reviser_tools,
+            react_max_iters=react_max_iters,
+        )
+        self.arbiter = build_predictor(
+            ArbitrateFullTrajectory,
+            arbiter_module_type,
+            role="arbiter",
+            lm=arbiter_lm,
+            tool_names=arbiter_tools,
+            react_max_iters=react_max_iters,
+        )
+
+    def forward(self, problem: str, context: str = "") -> dspy.Prediction:
+        trajectory = DeliberationTrajectory()
+        proposal_ids: list[str] = []
+
+        # Proposals are deliberately independent: no peer history is provided.
+        for index, perspective in enumerate(self.perspectives, start=1):
+            proposal = self.proposer(
+                problem=problem,
+                context=context,
+                perspective=perspective,
+            )
+            trajectory = trajectory.record(
+                round_index=0,
+                role=f"proposer-{index}",
+                kind="proposal",
+                content=proposal.answer,
+                reasoning=proposal.reasoning,
+                claims=tuple(proposal.claims),
+                evidence_ids=tuple(proposal.evidence_ids),
+            )
+            proposal_ids.append(trajectory.events[-1].event_id)
+
+        proposal_view = HistoryView(event_ids=tuple(proposal_ids), anonymize_roles=True)
+        conflict_result = self.conflict_selector(
+            problem=problem,
+            proposals=trajectory.render(proposal_view),
+        )
+        selected_ids = [
+            event_id
+            for event_id in conflict_result.selected_event_ids
+            if event_id in proposal_ids
+        ]
+        # A malformed or over-pruned selector must not silently eliminate debate.
+        if len(selected_ids) < 2:
+            selected_ids = proposal_ids
+
+        revision_ids: list[str] = []
+        for index, own_event_id in enumerate(proposal_ids, start=1):
+            opposing_ids = [
+                event_id for event_id in selected_ids if event_id != own_event_id
+            ]
+            opposing_view = HistoryView(
+                event_ids=tuple(opposing_ids), anonymize_roles=True
+            )
+            original = trajectory.get(own_event_id)
+            revision = self.reviser(
+                problem=problem,
+                context=context,
+                original_answer=original.content,
+                opposing_arguments=trajectory.render(opposing_view),
+                conflicts=list(conflict_result.conflicts),
+            )
+            trajectory = trajectory.record(
+                round_index=1,
+                role=f"proposer-{index}",
+                kind="revision",
+                content=revision.revised_answer,
+                reasoning=revision.reasoning,
+                claims=tuple(
+                    [*revision.retained_claims, *revision.accepted_corrections]
+                ),
+                parent_ids=(own_event_id, *opposing_ids),
+            )
+            revision_ids.append(trajectory.events[-1].event_id)
+
+        if self.on_iteration is not None:
+            self.on_iteration(
+                IterationEvent(
+                    iteration=1,
+                    exchange=ConsensusFreeDebateRound(
+                        proposal_ids=tuple(proposal_ids),
+                        revision_ids=tuple(revision_ids),
+                        conflicts=tuple(conflict_result.conflicts),
+                    ),
+                    history=trajectory.render(),
+                )
+            )
+
+        arbitration = self.arbiter(
+            problem=problem,
+            context=context,
+            trajectory=trajectory.render(
+                HistoryView(anonymize_roles=True, include_reasoning=True)
+            ),
+        )
+        known_candidate_ids = {*proposal_ids, *revision_ids}
+        winning_event_id = arbitration.winning_event_id
+        judgment_parents = (
+            (winning_event_id,)
+            if winning_event_id in known_candidate_ids
+            else tuple(revision_ids)
+        )
+        trajectory = trajectory.record(
+            round_index=1,
+            role="arbiter",
+            kind="judgment",
+            content=arbitration.final_answer,
+            reasoning=arbitration.justification,
+            parent_ids=judgment_parents,
+        )
+
+        return dspy.Prediction(
+            final_answer=arbitration.final_answer,
+            justification=arbitration.justification,
+            trajectory=trajectory,
+            history=trajectory.events,
+            iterations_used=1,
+            stopped_early=False,
+            stop_reason="completed",
+        )

--- a/awesome_dspy_agents/patterns/debate/consensus_free.py
+++ b/awesome_dspy_agents/patterns/debate/consensus_free.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass
 import dspy
 
 from awesome_dspy_agents.patterns.deliberation import (
+    DeliberationDelta,
     DeliberationTrajectory,
+    EvidenceArtifact,
     HistoryView,
 )
 from awesome_dspy_agents.predictor import build_predictor
@@ -98,15 +100,41 @@ class ConsensusFreeDebate(dspy.Module):
             react_max_iters=react_max_iters,
         )
 
-    def forward(self, problem: str, context: str = "") -> dspy.Prediction:
+    def forward(
+        self,
+        problem: str,
+        context: str = "",
+        evidence: Sequence[EvidenceArtifact] = (),
+    ) -> dspy.Prediction:
         trajectory = DeliberationTrajectory()
-        proposal_ids: list[str] = []
+        evidence_event_ids: dict[str, str] = {}
+        for artifact in evidence:
+            if artifact.evidence_id in evidence_event_ids:
+                raise ValueError(f"Duplicate evidence ID: {artifact.evidence_id}")
+            trajectory = trajectory.record(
+                round_index=0,
+                role="evidence",
+                kind="tool_observation" if artifact.kind == "tool" else "evidence",
+                content=artifact.content,
+                source_id=artifact.evidence_id,
+            )
+            evidence_event_ids[artifact.evidence_id] = trajectory.events[-1].event_id
 
-        # Proposals are deliberately independent: no peer history is provided.
+        evidence_context = trajectory.render(
+            HistoryView(event_ids=tuple(evidence_event_ids.values()))
+        )
+        effective_context = context
+        if evidence:
+            effective_context = (
+                f"{context}\n\nStructured evidence:\n{evidence_context}".strip()
+            )
+
+        proposal_ids: list[str] = []
         for index, perspective in enumerate(self.perspectives, start=1):
+            # Proposals are deliberately independent: no peer history is provided.
             proposal = self.proposer(
                 problem=problem,
-                context=context,
+                context=effective_context,
                 perspective=perspective,
             )
             trajectory = trajectory.record(
@@ -116,11 +144,18 @@ class ConsensusFreeDebate(dspy.Module):
                 content=proposal.answer,
                 reasoning=proposal.reasoning,
                 claims=tuple(proposal.claims),
-                evidence_ids=tuple(proposal.evidence_ids),
+                evidence_ids=tuple(
+                    evidence_id
+                    for evidence_id in proposal.evidence_ids
+                    if evidence_id in evidence_event_ids
+                ),
             )
             proposal_ids.append(trajectory.events[-1].event_id)
 
-        proposal_view = HistoryView(event_ids=tuple(proposal_ids), anonymize_roles=True)
+        proposal_view = HistoryView(
+            event_ids=(*evidence_event_ids.values(), *proposal_ids),
+            anonymize_roles=True,
+        )
         conflict_result = self.conflict_selector(
             problem=problem,
             proposals=trajectory.render(proposal_view),
@@ -130,25 +165,58 @@ class ConsensusFreeDebate(dspy.Module):
             for event_id in conflict_result.selected_event_ids
             if event_id in proposal_ids
         ]
-        # A malformed or over-pruned selector must not silently eliminate debate.
         if len(selected_ids) < 2:
             selected_ids = proposal_ids
 
+        conflicts = tuple(conflict_result.conflicts)
+        trajectory = trajectory.record(
+            round_index=1,
+            role="conflict-selector",
+            kind="critique",
+            content="\n".join(conflicts)
+            or "No explicit conflict description returned.",
+            parent_ids=tuple(selected_ids),
+        )
+        conflict_event_id = trajectory.events[-1].event_id
+        routes = getattr(conflict_result, "conflict_routes", {}) or {}
+        conflicts_by_event = getattr(conflict_result, "conflicts_by_event", {}) or {}
+
         revision_ids: list[str] = []
         for index, own_event_id in enumerate(proposal_ids, start=1):
+            routed_ids = routes.get(own_event_id, selected_ids)
             opposing_ids = [
-                event_id for event_id in selected_ids if event_id != own_event_id
+                event_id
+                for event_id in routed_ids
+                if event_id in proposal_ids and event_id != own_event_id
+            ]
+            if not opposing_ids:
+                opposing_ids = [
+                    event_id for event_id in proposal_ids if event_id != own_event_id
+                ]
+            opposing_evidence_ids = {
+                evidence_id
+                for event_id in opposing_ids
+                for evidence_id in trajectory.get(event_id).evidence_ids
+            }
+            visible_evidence_events = [
+                event_id
+                for evidence_id, event_id in evidence_event_ids.items()
+                if evidence_id in opposing_evidence_ids
             ]
             opposing_view = HistoryView(
-                event_ids=tuple(opposing_ids), anonymize_roles=True
+                event_ids=(*visible_evidence_events, *opposing_ids),
+                anonymize_roles=True,
             )
             original = trajectory.get(own_event_id)
             revision = self.reviser(
                 problem=problem,
-                context=context,
+                context=effective_context,
                 original_answer=original.content,
                 opposing_arguments=trajectory.render(opposing_view),
-                conflicts=list(conflict_result.conflicts),
+                conflicts=list(conflicts_by_event.get(own_event_id, conflicts)),
+            )
+            revised_evidence_ids = getattr(
+                revision, "evidence_ids", original.evidence_ids
             )
             trajectory = trajectory.record(
                 round_index=1,
@@ -159,7 +227,17 @@ class ConsensusFreeDebate(dspy.Module):
                 claims=tuple(
                     [*revision.retained_claims, *revision.accepted_corrections]
                 ),
-                parent_ids=(own_event_id, *opposing_ids),
+                delta=DeliberationDelta(
+                    preserved=tuple(revision.retained_claims),
+                    rejected=tuple(revision.rejected_claims),
+                    accepted_corrections=tuple(revision.accepted_corrections),
+                ),
+                parent_ids=(own_event_id, *opposing_ids, conflict_event_id),
+                evidence_ids=tuple(
+                    evidence_id
+                    for evidence_id in revised_evidence_ids
+                    if evidence_id in evidence_event_ids
+                ),
             )
             revision_ids.append(trajectory.events[-1].event_id)
 
@@ -170,7 +248,7 @@ class ConsensusFreeDebate(dspy.Module):
                     exchange=ConsensusFreeDebateRound(
                         proposal_ids=tuple(proposal_ids),
                         revision_ids=tuple(revision_ids),
-                        conflicts=tuple(conflict_result.conflicts),
+                        conflicts=conflicts,
                     ),
                     history=trajectory.render(),
                 )
@@ -178,7 +256,7 @@ class ConsensusFreeDebate(dspy.Module):
 
         arbitration = self.arbiter(
             problem=problem,
-            context=context,
+            context=effective_context,
             trajectory=trajectory.render(
                 HistoryView(anonymize_roles=True, include_reasoning=True)
             ),
@@ -207,4 +285,5 @@ class ConsensusFreeDebate(dspy.Module):
             iterations_used=1,
             stopped_early=False,
             stop_reason="completed",
+            candidate_scores=getattr(arbitration, "candidate_scores", {}),
         )

--- a/awesome_dspy_agents/patterns/debate/consensus_free.py
+++ b/awesome_dspy_agents/patterns/debate/consensus_free.py
@@ -13,6 +13,7 @@ from awesome_dspy_agents.patterns.deliberation import (
 )
 from awesome_dspy_agents.predictor import build_predictor
 from awesome_dspy_agents.runtime import EmitIteration, IterationEvent
+from awesome_dspy_agents.tools.registry import ToolEvent, tool_event_listener_scope
 
 from .consensus_free_signatures import (
     ArbitrateFullTrajectory,
@@ -129,10 +130,53 @@ class ConsensusFreeDebate(dspy.Module):
                 f"{context}\n\nStructured evidence:\n{evidence_context}".strip()
             )
 
+        tool_observation_index = 0
+
+        def invoke(
+            predictor: dspy.Module,
+            *,
+            role: str,
+            round_index: int,
+            **inputs: object,
+        ) -> tuple[dspy.Prediction, tuple[str, ...]]:
+            nonlocal tool_observation_index, trajectory
+            tool_events: list[ToolEvent] = []
+            with tool_event_listener_scope(tool_events.append):
+                prediction = predictor(**inputs)
+
+            observation_ids: list[str] = []
+            for tool_event in tool_events:
+                if tool_event.kind not in {"tool_result", "tool_error"}:
+                    continue
+                tool_observation_index += 1
+                source_id = f"tool-{tool_observation_index}"
+                while source_id in evidence_event_ids:
+                    tool_observation_index += 1
+                    source_id = f"tool-{tool_observation_index}"
+                content = str(
+                    tool_event.details.get(
+                        "result_preview", tool_event.details.get("error", "")
+                    )
+                )
+                trajectory = trajectory.record(
+                    round_index=round_index,
+                    role=role,
+                    kind="tool_observation",
+                    content=content,
+                    reasoning=f"Result from tool: {tool_event.tool}",
+                    source_id=source_id,
+                )
+                evidence_event_ids[source_id] = trajectory.events[-1].event_id
+                observation_ids.append(source_id)
+            return prediction, tuple(observation_ids)
+
         proposal_ids: list[str] = []
         for index, perspective in enumerate(self.perspectives, start=1):
             # Proposals are deliberately independent: no peer history is provided.
-            proposal = self.proposer(
+            proposal, tool_evidence_ids = invoke(
+                self.proposer,
+                role=f"proposer-{index}",
+                round_index=0,
                 problem=problem,
                 context=effective_context,
                 perspective=perspective,
@@ -145,9 +189,16 @@ class ConsensusFreeDebate(dspy.Module):
                 reasoning=proposal.reasoning,
                 claims=tuple(proposal.claims),
                 evidence_ids=tuple(
-                    evidence_id
-                    for evidence_id in proposal.evidence_ids
-                    if evidence_id in evidence_event_ids
+                    dict.fromkeys(
+                        [
+                            *(
+                                evidence_id
+                                for evidence_id in proposal.evidence_ids
+                                if evidence_id in evidence_event_ids
+                            ),
+                            *tool_evidence_ids,
+                        ]
+                    )
                 ),
             )
             proposal_ids.append(trajectory.events[-1].event_id)
@@ -156,33 +207,43 @@ class ConsensusFreeDebate(dspy.Module):
             event_ids=(*evidence_event_ids.values(), *proposal_ids),
             anonymize_roles=True,
         )
-        conflict_result = self.conflict_selector(
+        conflict_result, selector_tool_evidence_ids = invoke(
+            self.conflict_selector,
+            role="conflict-selector",
+            round_index=1,
             problem=problem,
             proposals=trajectory.render(proposal_view),
         )
+        raw_selected_ids = list(conflict_result.selected_event_ids)
+        conflicts = tuple(conflict_result.conflicts)
+        no_conflict = not raw_selected_ids and not conflicts
         selected_ids = [
-            event_id
-            for event_id in conflict_result.selected_event_ids
-            if event_id in proposal_ids
+            event_id for event_id in raw_selected_ids if event_id in proposal_ids
         ]
-        if len(selected_ids) < 2:
+        if not no_conflict and len(selected_ids) < 2:
             selected_ids = proposal_ids
 
-        conflicts = tuple(conflict_result.conflicts)
         trajectory = trajectory.record(
             round_index=1,
             role="conflict-selector",
             kind="critique",
-            content="\n".join(conflicts)
-            or "No explicit conflict description returned.",
-            parent_ids=tuple(selected_ids),
+            content=(
+                "No meaningful conflict selected."
+                if no_conflict
+                else "\n".join(conflicts)
+                or "Conflict selector returned candidates without a description."
+            ),
+            parent_ids=tuple(selected_ids or proposal_ids),
+            evidence_ids=selector_tool_evidence_ids,
         )
         conflict_event_id = trajectory.events[-1].event_id
         routes = getattr(conflict_result, "conflict_routes", {}) or {}
         conflicts_by_event = getattr(conflict_result, "conflicts_by_event", {}) or {}
 
         revision_ids: list[str] = []
-        for index, own_event_id in enumerate(proposal_ids, start=1):
+        for index, own_event_id in (
+            enumerate(proposal_ids, start=1) if not no_conflict else ()
+        ):
             routed_ids = routes.get(own_event_id, selected_ids)
             opposing_ids = [
                 event_id
@@ -208,7 +269,10 @@ class ConsensusFreeDebate(dspy.Module):
                 anonymize_roles=True,
             )
             original = trajectory.get(own_event_id)
-            revision = self.reviser(
+            revision, revision_tool_evidence_ids = invoke(
+                self.reviser,
+                role=f"proposer-{index}",
+                round_index=1,
                 problem=problem,
                 context=effective_context,
                 original_answer=original.content,
@@ -234,9 +298,16 @@ class ConsensusFreeDebate(dspy.Module):
                 ),
                 parent_ids=(own_event_id, *opposing_ids, conflict_event_id),
                 evidence_ids=tuple(
-                    evidence_id
-                    for evidence_id in revised_evidence_ids
-                    if evidence_id in evidence_event_ids
+                    dict.fromkeys(
+                        [
+                            *(
+                                evidence_id
+                                for evidence_id in revised_evidence_ids
+                                if evidence_id in evidence_event_ids
+                            ),
+                            *revision_tool_evidence_ids,
+                        ]
+                    )
                 ),
             )
             revision_ids.append(trajectory.events[-1].event_id)
@@ -254,27 +325,38 @@ class ConsensusFreeDebate(dspy.Module):
                 )
             )
 
-        arbitration = self.arbiter(
+        candidate_event_ids = [*proposal_ids, *revision_ids]
+        arbitration, arbiter_tool_evidence_ids = invoke(
+            self.arbiter,
+            role="arbiter",
+            round_index=1,
             problem=problem,
             context=effective_context,
+            candidate_event_ids=candidate_event_ids,
             trajectory=trajectory.render(
                 HistoryView(anonymize_roles=True, include_reasoning=True)
             ),
         )
-        known_candidate_ids = {*proposal_ids, *revision_ids}
+        known_candidate_ids = set(candidate_event_ids)
         winning_event_id = arbitration.winning_event_id
-        judgment_parents = (
-            (winning_event_id,)
-            if winning_event_id in known_candidate_ids
-            else tuple(revision_ids)
-        )
+        if winning_event_id not in known_candidate_ids:
+            raise ValueError(
+                f"Arbiter selected non-candidate event ID: {winning_event_id}"
+            )
+        candidate_scores = dict(arbitration.candidate_scores)
+        missing_scores = known_candidate_ids - set(candidate_scores)
+        if missing_scores:
+            raise ValueError(
+                f"Arbiter did not score candidate event IDs: {sorted(missing_scores)}"
+            )
         trajectory = trajectory.record(
             round_index=1,
             role="arbiter",
             kind="judgment",
             content=arbitration.final_answer,
             reasoning=arbitration.justification,
-            parent_ids=judgment_parents,
+            parent_ids=(winning_event_id,),
+            evidence_ids=arbiter_tool_evidence_ids,
         )
 
         return dspy.Prediction(
@@ -282,8 +364,8 @@ class ConsensusFreeDebate(dspy.Module):
             justification=arbitration.justification,
             trajectory=trajectory,
             history=trajectory.events,
-            iterations_used=1,
-            stopped_early=False,
-            stop_reason="completed",
-            candidate_scores=getattr(arbitration, "candidate_scores", {}),
+            iterations_used=0 if no_conflict else 1,
+            stopped_early=no_conflict,
+            stop_reason="no_conflict" if no_conflict else "completed",
+            candidate_scores=candidate_scores,
         )

--- a/awesome_dspy_agents/patterns/debate/consensus_free_signatures.py
+++ b/awesome_dspy_agents/patterns/debate/consensus_free_signatures.py
@@ -70,6 +70,9 @@ class ArbitrateFullTrajectory(dspy.Signature):
 
     problem: str = dspy.InputField()
     context: str = dspy.InputField()
+    candidate_event_ids: list[str] = dspy.InputField(
+        desc="Every proposal or revision event that must receive a score"
+    )
     trajectory: str = dspy.InputField(
         desc="Anonymous proposals and revisions from every round"
     )

--- a/awesome_dspy_agents/patterns/debate/consensus_free_signatures.py
+++ b/awesome_dspy_agents/patterns/debate/consensus_free_signatures.py
@@ -1,0 +1,74 @@
+import dspy
+
+
+class IndependentProposal(dspy.Signature):
+    """Solve independently before seeing any other agent's answer."""
+
+    problem: str = dspy.InputField(desc="Problem or instruction to solve")
+    context: str = dspy.InputField(desc="Evidence and context available to the agent")
+    perspective: str = dspy.InputField(
+        desc="Assigned perspective; it must not override evidence"
+    )
+
+    answer: str = dspy.OutputField(desc="Independent candidate answer")
+    claims: list[str] = dspy.OutputField(desc="Atomic claims supporting the answer")
+    evidence_ids: list[str] = dspy.OutputField(
+        desc="Identifiers of evidence used by the answer"
+    )
+    reasoning: str = dspy.OutputField(desc="Concise rationale for the proposal")
+
+
+class SelectConflicts(dspy.Signature):
+    """Retain the most consequential disagreements without resolving them."""
+
+    problem: str = dspy.InputField()
+    proposals: str = dspy.InputField(desc="Anonymous independent proposals")
+
+    selected_event_ids: list[str] = dspy.OutputField(
+        desc="Proposal or revision event IDs involved in meaningful disagreement"
+    )
+    conflicts: list[str] = dspy.OutputField(
+        desc="Specific contradictory claims, evidence, or conclusions"
+    )
+
+
+class ReviseWithoutConformity(dspy.Signature):
+    """Reassess an answer without assuming that agreement or majority is correct."""
+
+    problem: str = dspy.InputField()
+    context: str = dspy.InputField()
+    original_answer: str = dspy.InputField()
+    opposing_arguments: str = dspy.InputField(
+        desc="Selected anonymous disagreements from other agents"
+    )
+    conflicts: list[str] = dspy.InputField()
+
+    retained_claims: list[str] = dspy.OutputField(
+        desc="Original claims retained because they remain supported"
+    )
+    rejected_claims: list[str] = dspy.OutputField(
+        desc="Original claims rejected after concrete counter-evidence"
+    )
+    accepted_corrections: list[str] = dspy.OutputField(
+        desc="Corrections accepted from opposing arguments with justification"
+    )
+    revised_answer: str = dspy.OutputField()
+    reasoning: str = dspy.OutputField(desc="Why the answer changed or remained stable")
+
+
+class ArbitrateFullTrajectory(dspy.Signature):
+    """Choose the best-supported answer from the entire reasoning trajectory."""
+
+    problem: str = dspy.InputField()
+    context: str = dspy.InputField()
+    trajectory: str = dspy.InputField(
+        desc="Anonymous proposals and revisions from every round"
+    )
+
+    winning_event_id: str = dspy.OutputField(
+        desc="Event ID containing the strongest answer"
+    )
+    final_answer: str = dspy.OutputField()
+    justification: str = dspy.OutputField(
+        desc="Evidence-based reason for selecting this trajectory"
+    )

--- a/awesome_dspy_agents/patterns/debate/consensus_free_signatures.py
+++ b/awesome_dspy_agents/patterns/debate/consensus_free_signatures.py
@@ -30,6 +30,12 @@ class SelectConflicts(dspy.Signature):
     conflicts: list[str] = dspy.OutputField(
         desc="Specific contradictory claims, evidence, or conclusions"
     )
+    conflict_routes: dict[str, list[str]] = dspy.OutputField(
+        desc="For each candidate event ID, the opposing event IDs it should inspect"
+    )
+    conflicts_by_event: dict[str, list[str]] = dspy.OutputField(
+        desc="For each candidate event ID, only its relevant conflict descriptions"
+    )
 
 
 class ReviseWithoutConformity(dspy.Signature):
@@ -52,6 +58,9 @@ class ReviseWithoutConformity(dspy.Signature):
     accepted_corrections: list[str] = dspy.OutputField(
         desc="Corrections accepted from opposing arguments with justification"
     )
+    evidence_ids: list[str] = dspy.OutputField(
+        desc="Identifiers of supplied evidence supporting the revised answer"
+    )
     revised_answer: str = dspy.OutputField()
     reasoning: str = dspy.OutputField(desc="Why the answer changed or remained stable")
 
@@ -67,6 +76,9 @@ class ArbitrateFullTrajectory(dspy.Signature):
 
     winning_event_id: str = dspy.OutputField(
         desc="Event ID containing the strongest answer"
+    )
+    candidate_scores: dict[str, float] = dspy.OutputField(
+        desc="Evidence-grounded score for every proposal or revision considered"
     )
     final_answer: str = dspy.OutputField()
     justification: str = dspy.OutputField(

--- a/awesome_dspy_agents/patterns/debate/pattern.py
+++ b/awesome_dspy_agents/patterns/debate/pattern.py
@@ -7,6 +7,7 @@ import dspy  # type: ignore
 from awesome_dspy_agents.config import AppConfig, build_lm, load_config
 from awesome_dspy_agents.logging_setup import get_logger
 from awesome_dspy_agents.mlflow_integration import mlflow_span
+from awesome_dspy_agents.patterns.deliberation import DeliberationTrajectory
 from awesome_dspy_agents.patterns.interface import AgentPattern
 from awesome_dspy_agents.predictor import build_predictor
 from awesome_dspy_agents.runtime import (
@@ -21,6 +22,7 @@ from awesome_dspy_agents.tools.registry import (
     set_current_iteration,
 )
 
+from .consensus_free import ConsensusFreeDebate
 from .signatures import (
     AffirmativeDebater,
     JudgeDiscriminative,
@@ -281,6 +283,7 @@ class MADFramework(dspy.Module):
     ):
         """Run complete debate process."""
         history: list[DebateExchange] = []
+        trajectory = DeliberationTrajectory()
         solution_found = False
         final_answer = None
 
@@ -350,6 +353,24 @@ class MADFramework(dspy.Module):
                             }
                         )
 
+                trajectory = trajectory.record(
+                    round_index=iteration,
+                    role="affirmative",
+                    kind="proposal",
+                    content=aff_response.argument,
+                    reasoning=aff_response.reasoning,
+                )
+                affirmative_event_id = trajectory.events[-1].event_id
+                trajectory = trajectory.record(
+                    round_index=iteration,
+                    role="negative",
+                    kind="critique",
+                    content=neg_response.counter_argument,
+                    reasoning=neg_response.reasoning,
+                    parent_ids=(affirmative_event_id,),
+                )
+                negative_event_id = trajectory.events[-1].event_id
+
                 # Record exchange
                 exchange = DebateExchange(
                     affirmative=aff_response.argument,
@@ -405,6 +426,18 @@ class MADFramework(dspy.Module):
 
                     exchange = replace(exchange, judge_eval=judge_eval.reasoning)
                     history[-1] = exchange
+                    trajectory = trajectory.record(
+                        round_index=iteration,
+                        role="judge",
+                        kind="judgment",
+                        content=(
+                            "solution found"
+                            if judge_eval.solution_found
+                            else "continue deliberation"
+                        ),
+                        reasoning=judge_eval.reasoning,
+                        parent_ids=(affirmative_event_id, negative_event_id),
+                    )
 
                     # Callback after judge evaluation
                     if self.on_iteration is not None:
@@ -445,6 +478,14 @@ class MADFramework(dspy.Module):
                                         "justification": final_answer.justification,
                                     }
                                 )
+                        trajectory = trajectory.record(
+                            round_index=iteration,
+                            role="judge",
+                            kind="judgment",
+                            content=final_answer.final_answer,
+                            reasoning=final_answer.justification,
+                            parent_ids=(affirmative_event_id, negative_event_id),
+                        )
                         break
             finally:
                 reset_current_iteration(iter_token)
@@ -480,22 +521,40 @@ class MADFramework(dspy.Module):
                         }
                     )
             final_answer = final_prediction
+            parent_ids = tuple(
+                event.event_id
+                for event in trajectory.events
+                if event.kind in {"proposal", "critique"}
+                and event.round_index == len(history)
+            )
+            trajectory = trajectory.record(
+                round_index=len(history),
+                role="judge",
+                kind="judgment",
+                content=final_prediction.final_answer,
+                reasoning=final_prediction.justification,
+                parent_ids=parent_ids,
+            )
 
         if final_answer is None:
             return dspy.Prediction(
                 final_answer="",
                 justification="",
                 history=history,
+                trajectory=trajectory,
                 iterations_used=len(history),
                 stopped_early=solution_found,
+                stop_reason="no_answer",
             )
 
         return dspy.Prediction(
             final_answer=final_answer.final_answer,
             justification=final_answer.justification,
             history=history,
+            trajectory=trajectory,
             iterations_used=len(history),
             stopped_early=solution_found,
+            stop_reason="solution_found" if solution_found else "iteration_budget",
         )
 
 
@@ -554,6 +613,75 @@ class DebatePattern(AgentPattern):
             cfg: AppConfig,
             emit: Callable[[IterationEvent], None],
         ) -> PatternOutcome:
+            if cfg.debate.protocol == "consensus_free":
+                proposer_cfg = cfg.agents.get("proposer")
+                selector_cfg = cfg.agents.get("conflict_selector")
+                reviser_cfg = cfg.agents.get("reviser")
+                arbiter_cfg = cfg.agents.get("arbiter")
+                framework = ConsensusFreeDebate(
+                    agent_count=cfg.debate.agent_count,
+                    perspectives=cfg.debate.perspectives,
+                    proposer_module_type=(
+                        proposer_cfg.module_type if proposer_cfg else "predict"
+                    ),
+                    conflict_selector_module_type=(
+                        selector_cfg.module_type if selector_cfg else "predict"
+                    ),
+                    reviser_module_type=(
+                        reviser_cfg.module_type if reviser_cfg else "predict"
+                    ),
+                    arbiter_module_type=(
+                        arbiter_cfg.module_type
+                        if arbiter_cfg
+                        else cfg.judge.module_type
+                    ),
+                    proposer_lm=(
+                        build_lm(proposer_cfg.lm)
+                        if proposer_cfg and proposer_cfg.lm
+                        else None
+                    ),
+                    conflict_selector_lm=(
+                        build_lm(selector_cfg.lm)
+                        if selector_cfg and selector_cfg.lm
+                        else (
+                            build_lm(cfg.judge.discriminative_lm)
+                            if cfg.judge.discriminative_lm
+                            else None
+                        )
+                    ),
+                    reviser_lm=(
+                        build_lm(reviser_cfg.lm)
+                        if reviser_cfg and reviser_cfg.lm
+                        else None
+                    ),
+                    arbiter_lm=(
+                        build_lm(arbiter_cfg.lm)
+                        if arbiter_cfg and arbiter_cfg.lm
+                        else (
+                            build_lm(cfg.judge.extractive_lm)
+                            if cfg.judge.extractive_lm
+                            else None
+                        )
+                    ),
+                    proposer_tools=(proposer_cfg.tools if proposer_cfg else []),
+                    conflict_selector_tools=(
+                        selector_cfg.tools if selector_cfg else []
+                    ),
+                    reviser_tools=(reviser_cfg.tools if reviser_cfg else []),
+                    arbiter_tools=(
+                        arbiter_cfg.tools if arbiter_cfg else cfg.judge.tools
+                    ),
+                    on_iteration=emit,
+                )
+                final = framework(problem=current_request.topic, context="")
+                return PatternOutcome(
+                    final_answer=final.final_answer,
+                    justification=final.justification,
+                    iterations_used=final.iterations_used,
+                    stopped_early=final.stopped_early,
+                    history=list(final.history),
+                )
+
             aff_cfg = cfg.agents.get("affirmative")
             neg_cfg = cfg.agents.get("negative")
             framework = MADFramework(

--- a/awesome_dspy_agents/patterns/debate/scenarios/consensus_free.yaml
+++ b/awesome_dspy_agents/patterns/debate/scenarios/consensus_free.yaml
@@ -1,0 +1,18 @@
+debate:
+  protocol: consensus_free
+  agent_count: 2
+  # These labels encourage different independent analyses without assigning
+  # either agent a predetermined conclusion.
+  perspectives:
+    - Focus on the strongest direct evidence and check every assumption.
+    - Search for counterexamples, missing evidence, and alternative explanations.
+
+agents:
+  proposer:
+    module_type: predict
+  conflict_selector:
+    module_type: predict
+  reviser:
+    module_type: predict
+  arbiter:
+    module_type: predict

--- a/awesome_dspy_agents/patterns/deliberation/__init__.py
+++ b/awesome_dspy_agents/patterns/deliberation/__init__.py
@@ -1,15 +1,21 @@
 """Shared state and history views for multi-agent deliberation patterns."""
 
 from .trajectory import (
+    DeliberationDelta,
     DeliberationEvent,
     DeliberationTrajectory,
     EventKind,
+    EvidenceArtifact,
+    EvidenceKind,
     HistoryView,
 )
 
 __all__ = [
+    "DeliberationDelta",
     "DeliberationEvent",
     "DeliberationTrajectory",
     "EventKind",
+    "EvidenceArtifact",
+    "EvidenceKind",
     "HistoryView",
 ]

--- a/awesome_dspy_agents/patterns/deliberation/__init__.py
+++ b/awesome_dspy_agents/patterns/deliberation/__init__.py
@@ -1,0 +1,15 @@
+"""Shared state and history views for multi-agent deliberation patterns."""
+
+from .trajectory import (
+    DeliberationEvent,
+    DeliberationTrajectory,
+    EventKind,
+    HistoryView,
+)
+
+__all__ = [
+    "DeliberationEvent",
+    "DeliberationTrajectory",
+    "EventKind",
+    "HistoryView",
+]

--- a/awesome_dspy_agents/patterns/deliberation/trajectory.py
+++ b/awesome_dspy_agents/patterns/deliberation/trajectory.py
@@ -4,12 +4,35 @@ from dataclasses import dataclass
 from typing import Literal
 
 EventKind = Literal[
+    "evidence",
     "proposal",
     "critique",
     "revision",
     "tool_observation",
     "judgment",
 ]
+EvidenceKind = Literal["context", "document", "tool"]
+
+
+@dataclass(frozen=True)
+class EvidenceArtifact:
+    """Evidence supplied to a deliberation with a stable external identifier."""
+
+    evidence_id: str
+    content: str
+    kind: EvidenceKind = "document"
+
+
+@dataclass(frozen=True)
+class DeliberationDelta:
+    """Structured changes made by a proposal, critique, or revision."""
+
+    added: tuple[str, ...] = ()
+    removed: tuple[str, ...] = ()
+    removal_reasons: tuple[str, ...] = ()
+    preserved: tuple[str, ...] = ()
+    rejected: tuple[str, ...] = ()
+    accepted_corrections: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -23,8 +46,10 @@ class DeliberationEvent:
     content: str
     reasoning: str = ""
     claims: tuple[str, ...] = ()
+    delta: DeliberationDelta = DeliberationDelta()
     parent_ids: tuple[str, ...] = ()
     evidence_ids: tuple[str, ...] = ()
+    source_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -52,8 +77,10 @@ class DeliberationTrajectory:
         content: str,
         reasoning: str = "",
         claims: tuple[str, ...] = (),
+        delta: DeliberationDelta | None = None,
         parent_ids: tuple[str, ...] = (),
         evidence_ids: tuple[str, ...] = (),
+        source_id: str = "",
     ) -> DeliberationTrajectory:
         known_ids = {event.event_id for event in self.events}
         unknown_parents = set(parent_ids) - known_ids
@@ -69,8 +96,10 @@ class DeliberationTrajectory:
             content=content,
             reasoning=reasoning,
             claims=claims,
+            delta=delta or DeliberationDelta(),
             parent_ids=parent_ids,
             evidence_ids=evidence_ids,
+            source_id=source_id,
         )
         return DeliberationTrajectory(events=(*self.events, event))
 
@@ -104,6 +133,25 @@ class DeliberationTrajectory:
                 f"[{event.event_id} | round {event.round_index} | "
                 f"{role} | {event.kind}]\n{event.content}"
             )
+            if event.source_id:
+                lines.append(f"Source: {event.source_id}")
+            if event.claims:
+                lines.append(f"Claims: {'; '.join(event.claims)}")
+            if event.evidence_ids:
+                lines.append(f"Evidence: {', '.join(event.evidence_ids)}")
+            if event.parent_ids:
+                lines.append(f"Responds to: {', '.join(event.parent_ids)}")
+            delta_lines = (
+                ("Added", event.delta.added),
+                ("Removed", event.delta.removed),
+                ("Removal reasons", event.delta.removal_reasons),
+                ("Preserved", event.delta.preserved),
+                ("Rejected", event.delta.rejected),
+                ("Accepted corrections", event.delta.accepted_corrections),
+            )
+            for label, values in delta_lines:
+                if values:
+                    lines.append(f"{label}: {'; '.join(values)}")
             if view.include_reasoning and event.reasoning:
                 lines.append(f"Reasoning: {event.reasoning}")
         return "\n\n".join(lines)

--- a/awesome_dspy_agents/patterns/deliberation/trajectory.py
+++ b/awesome_dspy_agents/patterns/deliberation/trajectory.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+EventKind = Literal[
+    "proposal",
+    "critique",
+    "revision",
+    "tool_observation",
+    "judgment",
+]
+
+
+@dataclass(frozen=True)
+class DeliberationEvent:
+    """One immutable contribution to a deliberation trajectory."""
+
+    event_id: str
+    round_index: int
+    role: str
+    kind: EventKind
+    content: str
+    reasoning: str = ""
+    claims: tuple[str, ...] = ()
+    parent_ids: tuple[str, ...] = ()
+    evidence_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class HistoryView:
+    """A rendered, role-specific view over a trajectory."""
+
+    event_ids: tuple[str, ...] | None = None
+    exclude_roles: tuple[str, ...] = ()
+    anonymize_roles: bool = False
+    include_reasoning: bool = False
+
+
+@dataclass(frozen=True)
+class DeliberationTrajectory:
+    """Append-only deliberation state shared by agentic patterns."""
+
+    events: tuple[DeliberationEvent, ...] = ()
+
+    def record(
+        self,
+        *,
+        round_index: int,
+        role: str,
+        kind: EventKind,
+        content: str,
+        reasoning: str = "",
+        claims: tuple[str, ...] = (),
+        parent_ids: tuple[str, ...] = (),
+        evidence_ids: tuple[str, ...] = (),
+    ) -> DeliberationTrajectory:
+        known_ids = {event.event_id for event in self.events}
+        unknown_parents = set(parent_ids) - known_ids
+        if unknown_parents:
+            unknown = sorted(unknown_parents)
+            raise ValueError(f"Unknown trajectory event IDs: {unknown}")
+
+        event = DeliberationEvent(
+            event_id=f"event-{len(self.events) + 1}",
+            round_index=round_index,
+            role=role,
+            kind=kind,
+            content=content,
+            reasoning=reasoning,
+            claims=claims,
+            parent_ids=parent_ids,
+            evidence_ids=evidence_ids,
+        )
+        return DeliberationTrajectory(events=(*self.events, event))
+
+    def get(self, event_id: str) -> DeliberationEvent:
+        for event in self.events:
+            if event.event_id == event_id:
+                return event
+        raise KeyError(event_id)
+
+    def render(self, view: HistoryView | None = None) -> str:
+        view = view or HistoryView()
+        visible_ids = set(view.event_ids) if view.event_ids is not None else None
+        events = [
+            event
+            for event in self.events
+            if (visible_ids is None or event.event_id in visible_ids)
+            and event.role not in view.exclude_roles
+        ]
+        if not events:
+            return "No deliberation history yet."
+
+        role_aliases: dict[str, str] = {}
+        lines: list[str] = []
+        for event in events:
+            role = event.role
+            if view.anonymize_roles:
+                if role not in role_aliases:
+                    role_aliases[role] = f"Agent {chr(65 + len(role_aliases))}"
+                role = role_aliases[role]
+            lines.append(
+                f"[{event.event_id} | round {event.round_index} | "
+                f"{role} | {event.kind}]\n{event.content}"
+            )
+            if view.include_reasoning and event.reasoning:
+                lines.append(f"Reasoning: {event.reasoning}")
+        return "\n\n".join(lines)

--- a/awesome_dspy_agents/tools/registry.py
+++ b/awesome_dspy_agents/tools/registry.py
@@ -67,6 +67,20 @@ class ToolEvent:
 
 
 ToolListener = Callable[[ToolEvent], None]
+_ambient_tool_listeners: ContextVar[tuple[ToolListener, ...]] = ContextVar(
+    "dspy_agents_tool_listeners", default=()
+)
+
+
+@contextmanager
+def tool_event_listener_scope(listener: ToolListener) -> Iterator[None]:
+    """Observe tool events in the current execution context."""
+
+    token = _ambient_tool_listeners.set((*_ambient_tool_listeners.get(), listener))
+    try:
+        yield
+    finally:
+        _ambient_tool_listeners.reset(token)
 
 
 @dataclass(frozen=True)
@@ -140,13 +154,35 @@ class ToolExecutor:
     def build_dspy_tools(self, names: list[str]) -> list[dspy.Tool]:
         return [dspy.Tool(self.get(name)) for name in names]
 
-    def _emit(self, event: ToolEvent) -> None:
-        if self.listener is None:
-            return
-        try:
-            self.listener(event)
-        except Exception as error:
-            logger.warning("Tool listener failed for %s: %s", event.tool, error)
+    def _emit(
+        self,
+        event: ToolEvent,
+        *,
+        ambient_details: Mapping[str, Any] | None = None,
+    ) -> None:
+        ambient_event = (
+            ToolEvent(
+                event.kind,
+                event.tool,
+                event.agent,
+                event.iteration,
+                ambient_details,
+            )
+            if ambient_details is not None
+            else event
+        )
+        for listener in _ambient_tool_listeners.get():
+            if self.listener is not None and listener is self.listener:
+                continue
+            try:
+                listener(ambient_event)
+            except Exception as error:
+                logger.warning("Tool listener failed for %s: %s", event.tool, error)
+        if self.listener is not None:
+            try:
+                self.listener(event)
+            except Exception as error:
+                logger.warning("Tool listener failed for %s: %s", event.tool, error)
 
     def _instrument(
         self, name: str, function: Callable[..., Any]
@@ -179,7 +215,10 @@ class ToolExecutor:
             tools_logger.info(
                 "tool_result", tool=name, agent=agent, iteration=iteration, **details
             )
-            self._emit(ToolEvent("tool_result", name, agent, iteration, details))
+            self._emit(
+                ToolEvent("tool_result", name, agent, iteration, details),
+                ambient_details={**details, "result_preview": str(result)[:2000]},
+            )
             return result
 
         wrapped.__signature__ = inspect.signature(function)  # type: ignore[attr-defined]

--- a/tests/test_consensus_free_debate.py
+++ b/tests/test_consensus_free_debate.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+os.environ.setdefault(
+    "DSPY_CACHEDIR", f"{tempfile.gettempdir()}/dspy-agents-test-cache"
+)
+
+import dspy
+
+from awesome_dspy_agents.patterns.debate.consensus_free import ConsensusFreeDebate
+
+
+class _Proposer(dspy.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[dict[str, str]] = []
+
+    def forward(self, **inputs):
+        self.calls.append(inputs)
+        perspective = inputs["perspective"]
+        return dspy.Prediction(
+            answer=f"answer-{perspective}",
+            claims=[f"claim-{perspective}"],
+            evidence_ids=[],
+            reasoning=f"reason-{perspective}",
+        )
+
+
+class _ConflictSelector(dspy.Module):
+    def forward(self, **_inputs):
+        return dspy.Prediction(
+            selected_event_ids=["event-1", "event-2"],
+            conflicts=["The answers disagree"],
+        )
+
+
+class _Reviser(dspy.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[dict[str, str]] = []
+
+    def forward(self, **inputs):
+        self.calls.append(inputs)
+        return dspy.Prediction(
+            revised_answer=f"revised:{inputs['original_answer']}",
+            retained_claims=[],
+            rejected_claims=[],
+            accepted_corrections=[],
+            reasoning="reconsidered independently",
+        )
+
+
+class _Arbiter(dspy.Module):
+    def forward(self, **_inputs):
+        return dspy.Prediction(
+            winning_event_id="event-3",
+            final_answer="best answer",
+            justification="best supported trajectory",
+        )
+
+
+class ConsensusFreeDebateTests(unittest.TestCase):
+    def test_exposes_each_optimizable_role_as_a_named_predictor(self) -> None:
+        debate = ConsensusFreeDebate(agent_count=2)
+
+        names = {name for name, _predictor in debate.named_predictors()}
+
+        self.assertEqual(
+            names,
+            {
+                "proposer.predictor",
+                "conflict_selector.predictor",
+                "reviser.predictor",
+                "arbiter.predictor",
+            },
+        )
+
+    def test_runs_independent_proposals_then_revision_and_arbitration(self) -> None:
+        events = []
+        debate = ConsensusFreeDebate(agent_count=2, on_iteration=events.append)
+        proposer = _Proposer()
+        reviser = _Reviser()
+        debate.proposer = proposer
+        debate.conflict_selector = _ConflictSelector()
+        debate.reviser = reviser
+        debate.arbiter = _Arbiter()
+
+        result = debate(problem="What is correct?", context="Evidence")
+
+        self.assertEqual(result.final_answer, "best answer")
+        self.assertEqual(len(proposer.calls), 2)
+        self.assertNotIn("history", proposer.calls[0])
+        self.assertEqual(len(reviser.calls), 2)
+        self.assertNotIn("proposer-", reviser.calls[0]["opposing_arguments"])
+        self.assertEqual(
+            [event.kind for event in result.trajectory.events],
+            ["proposal", "proposal", "revision", "revision", "judgment"],
+        )
+        self.assertEqual(result.trajectory.events[2].parent_ids, ("event-1", "event-2"))
+        self.assertEqual(events[0].exchange.revision_ids, ("event-3", "event-4"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_consensus_free_debate.py
+++ b/tests/test_consensus_free_debate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import tempfile
 import unittest
 
@@ -12,6 +13,11 @@ import dspy
 
 from awesome_dspy_agents.patterns.debate.consensus_free import ConsensusFreeDebate
 from awesome_dspy_agents.patterns.deliberation import EvidenceArtifact
+from awesome_dspy_agents.tools.registry import (
+    FileAccessPolicy,
+    ToolExecutor,
+    default_catalog,
+)
 
 
 class _Proposer(dspy.Module):
@@ -28,6 +34,12 @@ class _Proposer(dspy.Module):
             evidence_ids=[],
             reasoning=f"reason-{perspective}",
         )
+
+
+class _ToolUsingProposer(_Proposer):
+    def forward(self, **inputs):
+        ToolExecutor(default_catalog, FileAccessPolicy()).get("word_count")("one two")
+        return super().forward(**inputs)
 
 
 class _ConflictSelector(dspy.Module):
@@ -75,10 +87,25 @@ class _Arbiter(dspy.Module):
 
     def forward(self, **_inputs):
         self.calls.append(_inputs)
+        candidate_ids = re.findall(
+            r"\[(event-\d+) \|[^\]]+\| (?:proposal|revision)\]",
+            _inputs["trajectory"],
+        )
         return dspy.Prediction(
-            winning_event_id="event-3",
+            winning_event_id=candidate_ids[-1],
+            candidate_scores={event_id: 1.0 for event_id in candidate_ids},
             final_answer="best answer",
             justification="best supported trajectory",
+        )
+
+
+class _NoConflictSelector(dspy.Module):
+    def forward(self, **_inputs):
+        return dspy.Prediction(
+            selected_event_ids=[],
+            conflicts=[],
+            conflict_routes={},
+            conflicts_by_event={},
         )
 
 
@@ -185,6 +212,49 @@ class ConsensusFreeDebateTests(unittest.TestCase):
         self.assertEqual(
             reviser.calls[0]["conflicts"], ["relevant to the first proposal"]
         )
+
+    def test_skips_revision_when_selector_finds_no_meaningful_conflict(self) -> None:
+        debate = ConsensusFreeDebate(agent_count=2)
+        reviser = _Reviser()
+        debate.proposer = _Proposer()
+        debate.conflict_selector = _NoConflictSelector()
+        debate.reviser = reviser
+        debate.arbiter = _Arbiter()
+
+        result = debate(problem="What is correct?")
+
+        self.assertEqual(reviser.calls, [])
+        self.assertEqual(
+            [event.kind for event in result.trajectory.events],
+            ["proposal", "proposal", "critique", "judgment"],
+        )
+        self.assertEqual(result.iterations_used, 0)
+        self.assertTrue(result.stopped_early)
+        self.assertEqual(result.stop_reason, "no_conflict")
+        self.assertEqual(set(result.candidate_scores), {"event-1", "event-2"})
+
+    def test_records_live_agent_tool_results_and_attaches_them_to_proposals(
+        self,
+    ) -> None:
+        debate = ConsensusFreeDebate(agent_count=2)
+        debate.proposer = _ToolUsingProposer()
+        debate.conflict_selector = _ConflictSelector()
+        debate.reviser = _Reviser()
+        debate.arbiter = _Arbiter()
+
+        result = debate(problem="What is correct?")
+
+        tool_events = [
+            event
+            for event in result.trajectory.events
+            if event.kind == "tool_observation"
+        ]
+        proposals = [
+            event for event in result.trajectory.events if event.kind == "proposal"
+        ]
+        self.assertEqual([event.content for event in tool_events], ["2", "2"])
+        self.assertEqual(proposals[0].evidence_ids, (tool_events[0].source_id,))
+        self.assertEqual(proposals[1].evidence_ids, (tool_events[1].source_id,))
 
 
 if __name__ == "__main__":

--- a/tests/test_consensus_free_debate.py
+++ b/tests/test_consensus_free_debate.py
@@ -11,6 +11,7 @@ os.environ.setdefault(
 import dspy
 
 from awesome_dspy_agents.patterns.debate.consensus_free import ConsensusFreeDebate
+from awesome_dspy_agents.patterns.deliberation import EvidenceArtifact
 
 
 class _Proposer(dspy.Module):
@@ -37,6 +38,20 @@ class _ConflictSelector(dspy.Module):
         )
 
 
+class _RoutedConflictSelector(dspy.Module):
+    def forward(self, **_inputs):
+        return dspy.Prediction(
+            selected_event_ids=["event-1", "event-2", "event-3"],
+            conflicts=["global conflict"],
+            conflict_routes={
+                "event-1": ["event-2"],
+                "event-2": ["event-1"],
+                "event-3": ["event-1"],
+            },
+            conflicts_by_event={"event-1": ["relevant to the first proposal"]},
+        )
+
+
 class _Reviser(dspy.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -54,7 +69,12 @@ class _Reviser(dspy.Module):
 
 
 class _Arbiter(dspy.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = []
+
     def forward(self, **_inputs):
+        self.calls.append(_inputs)
         return dspy.Prediction(
             winning_event_id="event-3",
             final_answer="best answer",
@@ -97,10 +117,74 @@ class ConsensusFreeDebateTests(unittest.TestCase):
         self.assertNotIn("proposer-", reviser.calls[0]["opposing_arguments"])
         self.assertEqual(
             [event.kind for event in result.trajectory.events],
-            ["proposal", "proposal", "revision", "revision", "judgment"],
+            [
+                "proposal",
+                "proposal",
+                "critique",
+                "revision",
+                "revision",
+                "judgment",
+            ],
         )
-        self.assertEqual(result.trajectory.events[2].parent_ids, ("event-1", "event-2"))
-        self.assertEqual(events[0].exchange.revision_ids, ("event-3", "event-4"))
+        self.assertEqual(
+            result.trajectory.events[3].parent_ids,
+            ("event-1", "event-2", "event-3"),
+        )
+        self.assertEqual(events[0].exchange.revision_ids, ("event-4", "event-5"))
+
+    def test_records_and_validates_document_and_tool_evidence(self) -> None:
+        debate = ConsensusFreeDebate(agent_count=2)
+        proposer = _Proposer()
+        arbiter = _Arbiter()
+        debate.proposer = proposer
+        debate.conflict_selector = _ConflictSelector()
+        debate.reviser = _Reviser()
+        debate.arbiter = arbiter
+
+        original_forward = proposer.forward
+
+        def propose_with_evidence(**inputs):
+            prediction = original_forward(**inputs)
+            prediction.evidence_ids = ["document-1", "invented-source"]
+            return prediction
+
+        proposer.forward = propose_with_evidence
+        result = debate(
+            problem="What is correct?",
+            evidence=(
+                EvidenceArtifact("document-1", "Document evidence"),
+                EvidenceArtifact("tool-1", "Tool output", kind="tool"),
+            ),
+        )
+
+        self.assertEqual(
+            [event.kind for event in result.trajectory.events[:2]],
+            ["evidence", "tool_observation"],
+        )
+        self.assertEqual(result.trajectory.events[2].evidence_ids, ("document-1",))
+        self.assertIn("Source: document-1", arbiter.calls[0]["trajectory"])
+        self.assertNotIn("invented-source", arbiter.calls[0]["trajectory"])
+
+    def test_routes_only_relevant_conflicts_to_each_reviser(self) -> None:
+        debate = ConsensusFreeDebate(agent_count=3)
+        reviser = _Reviser()
+        debate.proposer = _Proposer()
+        debate.conflict_selector = _RoutedConflictSelector()
+        debate.reviser = reviser
+        debate.arbiter = _Arbiter()
+
+        debate(problem="What is correct?")
+
+        self.assertIn(
+            "answer-independent perspective 2", reviser.calls[0]["opposing_arguments"]
+        )
+        self.assertNotIn(
+            "answer-independent perspective 3",
+            reviser.calls[0]["opposing_arguments"],
+        )
+        self.assertEqual(
+            reviser.calls[0]["conflicts"], ["relevant to the first proposal"]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_deliberation.py
+++ b/tests/test_deliberation.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import unittest
+
+from awesome_dspy_agents.patterns.deliberation import (
+    DeliberationTrajectory,
+    HistoryView,
+)
+
+
+class DeliberationTrajectoryTests(unittest.TestCase):
+    def test_record_returns_a_new_trajectory_with_causal_events(self) -> None:
+        empty = DeliberationTrajectory()
+
+        proposed = empty.record(
+            round_index=1,
+            role="proposer-1",
+            kind="proposal",
+            content="Initial answer",
+        )
+        revised = proposed.record(
+            round_index=1,
+            role="proposer-1",
+            kind="revision",
+            content="Revised answer",
+            parent_ids=("event-1",),
+        )
+
+        self.assertEqual(empty.events, ())
+        self.assertEqual(proposed.events[0].event_id, "event-1")
+        self.assertEqual(revised.events[1].parent_ids, ("event-1",))
+
+    def test_render_can_select_and_anonymize_messages(self) -> None:
+        trajectory = DeliberationTrajectory()
+        trajectory = trajectory.record(
+            round_index=1,
+            role="proposer-1",
+            kind="proposal",
+            content="First answer",
+            reasoning="private chain",
+        )
+        trajectory = trajectory.record(
+            round_index=1,
+            role="proposer-2",
+            kind="proposal",
+            content="Second answer",
+        )
+
+        rendered = trajectory.render(
+            HistoryView(event_ids=("event-2",), anonymize_roles=True)
+        )
+
+        self.assertIn("Agent A", rendered)
+        self.assertIn("Second answer", rendered)
+        self.assertNotIn("proposer-2", rendered)
+        self.assertNotIn("First answer", rendered)
+        self.assertNotIn("private chain", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deliberation.py
+++ b/tests/test_deliberation.py
@@ -44,6 +44,8 @@ class DeliberationTrajectoryTests(unittest.TestCase):
             role="proposer-2",
             kind="proposal",
             content="Second answer",
+            claims=("Supported claim",),
+            evidence_ids=("document-7",),
         )
 
         rendered = trajectory.render(
@@ -55,6 +57,8 @@ class DeliberationTrajectoryTests(unittest.TestCase):
         self.assertNotIn("proposer-2", rendered)
         self.assertNotIn("First answer", rendered)
         self.assertNotIn("private chain", rendered)
+        self.assertIn("Claims: Supported claim", rendered)
+        self.assertIn("Evidence: document-7", rendered)
 
 
 if __name__ == "__main__":

--- a/tests/test_patterns_runtime.py
+++ b/tests/test_patterns_runtime.py
@@ -100,6 +100,42 @@ class PatternInterfaceTests(unittest.TestCase):
         self.assertEqual(result.final_answer, "Refined answer")
         self.assertEqual(result.history, prediction.history)
 
+    def test_debate_can_select_the_consensus_free_protocol(self) -> None:
+        prediction = SimpleNamespace(
+            final_answer="Consensus-free answer",
+            justification="Full trajectory",
+            iterations_used=1,
+            stopped_early=False,
+            history=("proposal", "revision"),
+        )
+        programs = []
+
+        def build_program(**settings):
+            program = _FakeProgram(prediction, **settings)
+            programs.append(program)
+            return program
+
+        with patch(
+            "awesome_dspy_agents.patterns.debate.pattern.ConsensusFreeDebate",
+            side_effect=build_program,
+        ):
+            result = DebatePattern().run(
+                PatternRunRequest(
+                    topic="Topic",
+                    config_path=self.config_path,
+                    overrides={
+                        "debate": {
+                            "protocol": "consensus_free",
+                            "agent_count": 3,
+                        }
+                    },
+                )
+            )
+
+        self.assertEqual(programs[0].settings["agent_count"], 3)
+        self.assertEqual(result.final_answer, "Consensus-free answer")
+        self.assertEqual(result.history, ["proposal", "revision"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -14,6 +14,7 @@ from awesome_dspy_agents.tools.registry import (
     ToolExecutor,
     default_catalog,
     math_eval,
+    tool_event_listener_scope,
 )
 
 
@@ -82,6 +83,23 @@ class ToolSecurityTests(unittest.TestCase):
         )
 
         self.assertEqual(executor.get("word_count")("one two"), "2")
+
+    def test_ambient_listener_receives_tool_result_content(self) -> None:
+        events = []
+        public_events = []
+        executor = ToolExecutor(
+            default_catalog, FileAccessPolicy(), listener=public_events.append
+        )
+
+        with tool_event_listener_scope(events.append):
+            executor.get("word_count")("one two")
+
+        result_event = next(event for event in events if event.kind == "tool_result")
+        public_result = next(
+            event for event in public_events if event.kind == "tool_result"
+        )
+        self.assertEqual(result_event.details["result_preview"], "2")
+        self.assertNotIn("result_preview", public_result.details)
 
 
 if __name__ == "__main__":

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -18,7 +18,12 @@ from awesome_dspy_agents.patterns.debate.pattern import DebateExchange, MADFrame
 
 
 class _Addition(dspy.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = []
+
     def forward(self, **_inputs):
+        self.calls.append(_inputs)
         return dspy.Prediction(candidate_response="draft", reasoning="reason")
 
 
@@ -59,7 +64,25 @@ class WorkflowStateTests(unittest.TestCase):
         self.assertEqual(len(second.history), 1)
         self.assertIsNot(first.history, second.history)
         self.assertIsInstance(events[0].exchange, AdditionBySubtractionExchange)
+        self.assertEqual(
+            [event.kind for event in first.trajectory.events],
+            ["proposal", "revision"],
+        )
         self.assertEqual(framework.history, [])  # DSPy base history remains untouched.
+
+    def test_addition_receives_the_latest_refined_state_not_only_a_transcript(
+        self,
+    ) -> None:
+        framework = ABSFramework(max_iterations=2)
+        addition = _Addition()
+        framework.addition = addition
+        framework.subtraction = _Subtraction()
+
+        framework(context="", instruction="improve this")
+
+        self.assertEqual(addition.calls[0]["current_response"], "")
+        self.assertEqual(addition.calls[1]["current_response"], "refined")
+        self.assertEqual(addition.calls[1]["previous_feedback"], "feedback")
 
     def test_debate_is_reusable_and_emits_typed_exchanges(self) -> None:
         events = []
@@ -77,6 +100,10 @@ class WorkflowStateTests(unittest.TestCase):
         self.assertEqual(len(second.history), 1)
         self.assertIsNot(first.history, second.history)
         self.assertIsInstance(events[0].exchange, DebateExchange)
+        self.assertEqual(
+            [event.kind for event in first.trajectory.events],
+            ["proposal", "critique", "judgment"],
+        )
         self.assertFalse(hasattr(framework, "debate_history"))
 
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -29,15 +29,23 @@ class _Addition(dspy.Module):
 
 class _Subtraction(dspy.Module):
     def forward(self, **_inputs):
-        return dspy.Prediction(refined_response="refined", feedback="feedback")
+        return dspy.Prediction(
+            refined_response="refined",
+            feedback="feedback",
+            removals=["repetition"],
+            removal_reasons=["duplicate"],
+            preserved_facts=["supported fact"],
+        )
 
 
 class _Debater(dspy.Module):
     def __init__(self, affirmative: bool) -> None:
         super().__init__()
         self.affirmative = affirmative
+        self.calls = []
 
     def forward(self, **_inputs):
+        self.calls.append(_inputs)
         if self.affirmative:
             return dspy.Prediction(argument="yes", reasoning="for")
         return dspy.Prediction(counter_argument="no", reasoning="against")
@@ -68,6 +76,7 @@ class WorkflowStateTests(unittest.TestCase):
             [event.kind for event in first.trajectory.events],
             ["proposal", "revision"],
         )
+        self.assertEqual(first.trajectory.events[1].delta.removed, ("repetition",))
         self.assertEqual(framework.history, [])  # DSPy base history remains untouched.
 
     def test_addition_receives_the_latest_refined_state_not_only_a_transcript(
@@ -105,6 +114,19 @@ class WorkflowStateTests(unittest.TestCase):
             ["proposal", "critique", "judgment"],
         )
         self.assertFalse(hasattr(framework, "debate_history"))
+
+    def test_classic_debate_preserves_its_legacy_history_prompt(self) -> None:
+        framework = MADFramework(max_iterations=2, adaptive_break=False)
+        affirmative = _Debater(True)
+        framework.affirmative = affirmative
+        framework.negative = _Debater(False)
+        framework.judge = _Judge()
+
+        framework(debate_topic="topic")
+
+        second_round_history = affirmative.calls[1]["debate_history"]
+        self.assertIn("--- Iteration 1 ---", second_round_history)
+        self.assertNotIn("[event-", second_round_history)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an immutable deliberation trajectory with selective anonymous history views, causal links, evidence provenance, and structured deltas
- add a consensus-free debate protocol with independent proposals, routed conflicts, anti-conformity revision, full-trajectory scoring, no-conflict early arbitration, and GEPA-discoverable predictors
- evolve Addition by Subtraction to carry refined state, feedback, additions, removals, reasons, and preserved facts across rounds
- preserve the classic adversarial debate interface and MLflow tracing while adding protocol selection and documentation
- capture live ReAct tool results as scoped trajectory evidence without exposing result content through public telemetry

## Verification
- 47 tests passed
- Ruff check and format check passed
- Pyrefly passed with 0 errors
- final standards and specification review found no remaining P1/P2 gaps